### PR TITLE
Update README.md, fixing examples with bad JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Created with :heart: for front-end developers who need a flexible back-end for q
 ```bash
 $ cat db.json
 { 
-  posts: [
-    { id: 1, body: 'foo' }
+  "posts": [
+    { "id": 1, "body": "foo" }
   ]
 }
 $ json-server --file db.json
@@ -29,9 +29,9 @@ $ curl -i http://localhost:3000/posts/1
 ```javascript
 var server = require('json-server');
 
-var db = {
-  posts: [
-    {id: 1, body: 'foo'}
+var db = { 
+  "posts": [
+    { "id": 1, "body": "foo" }
   ]
 }
 
@@ -97,13 +97,13 @@ Here's 2 examples showing how to format JSON or JS seed file:
 
 ```javascript
 {
-  posts: [
-    { id: 1, body: 'foo'},
-    { id: 2, body: 'bar'}
+  "posts": [
+    { "id": 1, "body": "foo"},
+    { "id": 2, "body": "bar"}
   ],
-  comments: [
-    { id: 1, body: 'baz', postId: 1}
-    { id: 2, body: 'qux', postId: 2}
+  "comments": [
+    { "id": 1, "body": "baz", "postId": 1}
+    { "id": 2, "body": "qux", "postId": 2}
   ]
 }
 ```
@@ -115,7 +115,7 @@ exports.run = function() {
   var data = {};
   
   data.posts = [];
-  data.posts.push({id: 1, body: 'foo'});
+  data.posts.push({"id": 1, "body": "foo"});
   //...
 
   return data;


### PR DESCRIPTION
The examples given in the README do not conform to the JSON specification. In fact, when run in the way shown, it doesn't even work. 

This commit fixes the formatting issues in the JSONs. They are mostly wrapping attribute names in quotes, and changing single quotes to double quotes.

I also made those changes to JS objects that weren't specifically JSON, but would be nice to be formatted like JSON in case someone wants to copy the example and paste it into a .json file.
