### PR TITLE
[RFR] Add total count when slicing collection

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -36,6 +36,9 @@ routes.list = function(req, res, next) {
   }
 
   if (_start) {
+	res.setHeader('X-Count', resource.length)
+	res.setHeader('Access-Control-Expose-Headers', 'X-Count')
+
     resource = resource.slice(_start, _end)
   }
 
@@ -56,7 +59,7 @@ routes.create = function(req, res, next) {
   for (var key in req.body) {
     req.body[key] = utils.toNative(req.body[key])
   }
-  
+
   var resource = low(req.params.resource)
     .insert(req.body)
     .value()
@@ -74,14 +77,14 @@ routes.update = function(req, res, next) {
   var resource = low(req.params.resource)
     .update(+req.params.id, req.body)
     .value()
-  
+
   res.jsonp(resource)
 }
 
 // DELETE /:resource/:id
 routes.destroy = function(req, res, next) {
   low(req.params.resource).remove(+req.params.id)
-  
+
   // Remove dependents documents
   var removable = utils.getRemovable(low.db)
 

--- a/test/server.js
+++ b/test/server.js
@@ -61,7 +61,11 @@ describe('Server', function() {
         .get('/comments?_start=1&_end=2')
         .expect('Content-Type', /json/)
         .expect(low.db.comments.slice(1, 2))
-        .expect(200, done)
+        .expect(200)
+        .end(function(err, res){
+          assert.equal(res.headers['x-count'], 5)
+          done()
+        })
     })
   })
 


### PR DESCRIPTION
When paginating, we need to know the total of element in the collection without executing another request.

If the `_start` param is provided, the server now returns a header : `X-Count` with the total of non-sliced elements in the collection.
