### PR TITLE
Docs/nested calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ GET /
 
 ### Nested calls
 
-Any nested objects need to be available in the root of the object, and reference its parent using `<parent-key>Id: <parent-id-value>`. In the above example, to return any `comments` objects for `post`s that have and `id` of `1` would be `/posts/1/comments`, so long as each `comments` object has a `postId` value.
+Any nested objects need to be available in the root of the object, and reference its parent using `<parent-key>Id: <parent-id-value>`. In the above example, to return any `comments` objects for `post`s that have and `id` of `1` would be `/posts/1/comments`, so long as each `comments` object has a `postId` value. *Note: if `parent-key` is plural, the `s` will be stripped when searching for `<parent-key>Id`, so `posts` will look for the `postId` value in the subsequent objects.*
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Returns default index file or serves `./public` directory.
 GET /
 ```
 
+### Nested calls
+
+Any nested objects need to be available in the root of the object, and reference its parent using `<parent-key>Id: <parent-id-value>`. In the above example, to return any `comments` objects for `post`s that have and `id` of `1` would be `/posts/1/comments`, so long as each `comments` object has a `postId` value.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Added a sub-section in the Requests portion to clarify the usage of nested calls a bit. You did list `posts/1/comments` in the list of routes, but it's kinda left up to the reader to figure out what that means. Hopefully this makes it a bit easier to pick up quickly. Also added a note about the plural => singular key references, if there is more functionality with that search, I'd be happy to update. References #72 