### PR TITLE
Fixing empty key/value when _embed is undefined/empty

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -149,17 +149,17 @@ module.exports = function (source) {
       .get(utils.toNative(req.params.id))
 
     if (resource) {
-      if (_embed && _embed.length > 0) {
-        // Always use an array
-        _embed = _.isArray(_embed) ? _embed : [_embed]
+      // Always use an array
+      _embed = _.isArray(_embed) ? _embed : [_embed]
 
-        // Embed other resources based on resource id
-        _embed.forEach(function () {
+      // Embed other resources based on resource id
+      _embed.forEach(function (otherResource) {
+        if (otherResource && otherResource.trim().length > 0) {
           var query = {}
           query[req.params.resource + 'Id'] = req.params.id
-          resource[_embed] = db(_embed).where(query)
-        })
-      }
+          resource[otherResource] = db(otherResource).where(query)
+        }
+      })
 
       // Return resource
       res.jsonp(resource)

--- a/src/router.js
+++ b/src/router.js
@@ -149,15 +149,17 @@ module.exports = function (source) {
       .get(utils.toNative(req.params.id))
 
     if (resource) {
-      // Always use an array
-      _embed = _.isArray(_embed) ? _embed : [_embed]
+      if (_embed && _embed.length > 0) {
+        // Always use an array
+        _embed = _.isArray(_embed) ? _embed : [_embed]
 
-      // Embed other resources based on resource id
-      _embed.forEach(function () {
-        var query = {}
-        query[req.params.resource + 'Id'] = req.params.id
-        resource[_embed] = db(_embed).where(query)
-      })
+        // Embed other resources based on resource id
+        _embed.forEach(function () {
+          var query = {}
+          query[req.params.resource + 'Id'] = req.params.id
+          resource[_embed] = db(_embed).where(query)
+        })
+      }
 
       // Return resource
       res.jsonp(resource)


### PR DESCRIPTION
Before I was getting responses with and empty key/value for `/resource/:id`.

```js
{
  id: 1,
  title: "My Title",
   : []
}
```

So this fixes it to only include the `_embed` keys if it is set and actually equal to something.
