### PR TITLE
Experimental mongodb migration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^3.9.2",
     "lowdb": "^0.7.1",
     "method-override": "^2.1.2",
+    "mongodb": "^2.0.33",
     "morgan": "^1.3.1",
     "node-uuid": "^1.4.2",
     "pluralize": "^1.1.2",

--- a/src/router.js
+++ b/src/router.js
@@ -39,8 +39,8 @@ module.exports = function (source) {
   function showDatabase (req, res, next) {
     res.jsonp(db.object)
   }
-  
-    // Connect to MongoDB
+
+  // Connect to MongoDB
   function connectToMongo (callback) {
     mongoClient.connect(connectToMongo.dbUrl, function (err, db) {
       if (err) {
@@ -205,9 +205,9 @@ module.exports = function (source) {
       // Embed other resources based on resource id
       _embed.forEach(function (otherResource) {
 
-        if (otherResource
-          && otherResource.trim().length > 0
-          && db.object[otherResource]) {
+        if (otherResource &&
+          otherResource.trim().length > 0 &&
+          db.object[otherResource]) {
           var query = {}
           var prop = pluralize.singular(req.params.resource) + 'Id'
           query[prop] = id
@@ -267,7 +267,7 @@ module.exports = function (source) {
   }
 
   router.get('/db', showDatabase)
-  
+
   router.route('/migrate').post(migrateDatabase)
 
   router.route('/:resource')

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,9 +8,9 @@ var pluralize = require('pluralize')
 //   '1' -> 1
 function toNative (value) {
   if (typeof value === 'string') {
-    if (value === ''
-       || value.trim() !== value
-       || (value.length > 1 && value[0] === '0')) {
+    if (value === '' ||
+       value.trim() !== value ||
+       (value.length > 1 && value[0] === '0')) {
       return value
     } else if (value === 'true' || value === 'false') {
       return value === 'true'

--- a/test/index.js
+++ b/test/index.js
@@ -226,6 +226,24 @@ describe('Server', function () {
   })
 
   describe('POST /:resource', function () {
+    it('should respond with a 400 http code',
+      function (done) {
+        request(server)
+          .post('/migrate')
+          .send({body: 'foo'})
+          .expect('Content-Type', /text/)
+          .expect(400, done)
+      })
+
+    it('should respond with a 503 http code',
+      function (done) {
+        this.timeout(3500)
+        request(server)
+          .post('/migrate')
+          .send({host: 'mongodb://localhost', port: '27017', db: 'test'})
+          .expect('Content-Type', /text/)
+          .expect(503, done)
+      })
     it('should respond with json, create a resource and increment id',
       function (done) {
         request(server)


### PR DESCRIPTION
I implemented an experimental "/migrate" post end-point where you can send the connection parameters of a mongoDB instance to migrate all the data in the current watched file to mongo. 

The data its pushed into collections with the name of their respective resource. The query have to be in the body of the post request with the following key names for the parameters:

host: mongodb://examplehost
db: exampleDB
port: 27017