### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a `db.json` file
 Start JSON Server
 
 ```bash
-$ json-server --watch db.json
+$ json-server db.json
 ```
 
 Now if you go to [http://localhost:3000/posts/1](), you'll get


### PR DESCRIPTION
Correct arguments on json-server start. json-server doesnt start if you provide --watch and the db.json file.

Tested it on both Windows and Mac machine.