### PR TITLE
Add _expand parameter when retrieving single resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ To embed other resources, add `_embed`.
 GET /posts/1?_embed=comments
 ```
 
+To expand related resources, add `_expand`.
+
+```
+GET /comments/1?_expand=posts
+```
+
 Returns database.
 
 ```

--- a/src/router.js
+++ b/src/router.js
@@ -159,6 +159,7 @@ module.exports = function (source) {
   // GET /:resource/:id
   function show (req, res, next) {
     var _embed = req.query._embed
+    var _expand = req.query._expand
     var id = utils.toNative(req.params.id)
     var resource = db(req.params.resource)
       .getById(id)
@@ -168,6 +169,7 @@ module.exports = function (source) {
       resource = _.cloneDeep(resource)
       // Always use an array
       _embed = _.isArray(_embed) ? _embed : [_embed]
+      _expand = _.isArray(_expand) ? _expand : [_expand]
 
       // Embed other resources based on resource id
       _embed.forEach(function (otherResource) {
@@ -180,6 +182,19 @@ module.exports = function (source) {
           query[prop] = id
           resource[otherResource] = db(otherResource).where(query)
 
+        }
+      })
+
+      // Expand inner resources based on id
+      _expand.forEach(function (innerResource) {
+
+        if (innerResource
+          && innerResource.trim().length > 0
+          && db.object[innerResource]) {
+          var query = {}
+          var prop = pluralize.singular(innerResource) + 'Id'
+          query.id = resource[prop]
+          resource[innerResource] = db(innerResource).where(query)
         }
       })
 

--- a/src/router.js
+++ b/src/router.js
@@ -191,10 +191,9 @@ module.exports = function (source) {
         if (innerResource
           && innerResource.trim().length > 0
           && db.object[innerResource]) {
-          var query = {}
-          var prop = pluralize.singular(innerResource) + 'Id'
-          query.id = resource[prop]
-          resource[innerResource] = db(innerResource).where(query)
+          var singular = pluralize.singular(innerResource)
+          var prop = singular + 'Id'
+          resource[singular] = db(innerResource).getById(resource[prop])
         }
       })
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,12 +24,17 @@ describe('Server', function () {
       {id: 3, body: 'photo'}
     ]
 
+    db.users = [
+      {id: 1, username: 'Jim'},
+      {id: 2, username: 'George'}
+    ]
+
     db.comments = [
-      {id: 1, published: true, postId: 1},
-      {id: 2, published: false, postId: 1},
-      {id: 3, published: false, postId: 2},
-      {id: 4, published: false, postId: 2},
-      {id: 5, published: false, postId: 2}
+      {id: 1, published: true, postId: 1, userId: 1},
+      {id: 2, published: false, postId: 1, userId: 2},
+      {id: 3, published: false, postId: 2, userId: 1},
+      {id: 4, published: false, postId: 2, userId: 2},
+      {id: 5, published: false, postId: 2, userId: 1}
     ]
 
     db.refs = [
@@ -238,6 +243,31 @@ describe('Server', function () {
         .get('/posts/1?_embed=comments&_embed=refs')
         .expect('Content-Type', /json/)
         .expect(posts)
+        .expect(200, done)
+    })
+  })
+
+  describe('GET /:resource/:id?_expand=', function () {
+    it('should respond with corresponding resource and expanded inner resources', function (done) {
+      var comments = db.comments[0]
+      comments.posts = [db.posts[0]]
+      request(server)
+        .get('/comments/1?_expand=posts')
+        .expect('Content-Type', /json/)
+        .expect(comments)
+        .expect(200, done)
+    })
+  })
+
+  describe('GET /:resource/:id?_expand=&_expand=', function () {
+    it('should respond with corresponding resource and expanded inner resources', function (done) {
+      var comments = db.comments[0]
+      comments.posts = [db.posts[0]]
+      comments.users = [db.users[0]]
+      request(server)
+        .get('/comments/1?_expand=posts&_expand=users')
+        .expect('Content-Type', /json/)
+        .expect(comments)
         .expect(200, done)
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -250,7 +250,7 @@ describe('Server', function () {
   describe('GET /:resource/:id?_expand=', function () {
     it('should respond with corresponding resource and expanded inner resources', function (done) {
       var comments = db.comments[0]
-      comments.posts = [db.posts[0]]
+      comments.post = db.posts[0]
       request(server)
         .get('/comments/1?_expand=posts')
         .expect('Content-Type', /json/)
@@ -262,8 +262,8 @@ describe('Server', function () {
   describe('GET /:resource/:id?_expand=&_expand=', function () {
     it('should respond with corresponding resource and expanded inner resources', function (done) {
       var comments = db.comments[0]
-      comments.posts = [db.posts[0]]
-      comments.users = [db.users[0]]
+      comments.post = db.posts[0]
+      comments.user = db.users[0]
       request(server)
         .get('/comments/1?_expand=posts&_expand=users')
         .expect('Content-Type', /json/)


### PR DESCRIPTION
Based on the conversation in #110 this PR adds an _expand parameter when retrieving single resources, basically the inverse of _embed.