### PR TITLE
Test case, String handling: /deepString?a.b=1111

### DIFF
--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -48,7 +48,7 @@ describe('Server', function () {
     ]
 
     db.deepString = [
-      { a: { b: 'one' } },
+      { a: { b: '1111' } },
       { a: '1' }
     ]
 
@@ -118,7 +118,7 @@ describe('Server', function () {
 
     it('should support deep filter with string', function (done) {
       request(server)
-        .get('/deepString?a.b=1')
+        .get('/deepString?a.b=1111')
         .expect('Content-Type', /json/)
         .expect([db.deepString[0]])
         .expect(200, done)

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -47,6 +47,11 @@ describe('Server', function () {
       { a: 1 }
     ]
 
+    db.deepString = [
+      { a: { b: 'one' } },
+      { a: '1' }
+    ]
+
     server = jsonServer.create()
     router = jsonServer.router(db)
     server.use(jsonServer.defaults())
@@ -108,6 +113,14 @@ describe('Server', function () {
         .get('/deep?a.b=1')
         .expect('Content-Type', /json/)
         .expect([db.deep[0]])
+        .expect(200, done)
+    })
+
+    it('should support deep filter with string', function (done) {
+      request(server)
+        .get('/deepString?a.b=1')
+        .expect('Content-Type', /json/)
+        .expect([db.deepString[0]])
         .expect(200, done)
     })
 


### PR DESCRIPTION
If I submit a GET request as /deepString?a.b=1111 and my JSON looks like:
```JSON
    db.deepString = [
      { a: { b: '1111' } },
      { a: '1' }
    ]
```
then I get an empty array: []