### PR TITLE
Add Dockunit file since Travis CI doesn't test Node.js 4.2.x

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,28 @@
+{
+  "containers": [
+    {
+      "prettyName": "nodejs 4.2.1",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-4.2.1",
+      "testCommand": "NODE_ENV=test mocha -R spec test/**/*.js",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.12.7",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.12.7",
+      "testCommand": "NODE_ENV=test mocha -R spec test/**/*.js",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.10.40",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.10.40",
+      "testCommand": "NODE_ENV=test mocha -R spec test/**/*.js",
+      "beforeScripts": [
+        "npm install"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests JSON Server in Node.js 4.2.1, 0.12.7, and 0.10.40. 4.2.x is not available yet on Travis CI. Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the current [Dockunit status of JSON Server here](https://dockunit.io/projects/tlovett1/json-server).
