### PR TITLE
Express middlewares wrapper - remove parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ var jsonServer = require('json-server')
 var server = jsonServer.create()
 
 // Set default middlewares (logger, static, cors and no-cache)
-server.use(jsonServer.defaults())
+server.use(jsonServer.defaults)
 
 // Add custom routes
 // server.get('/custom', function (req, res) { res.json({ msg: 'hello' }) })


### PR DESCRIPTION
Parenthesis throws TypeError: Property 'defaults' of object #<Object> is not a function