### PR TITLE
Allow disabling of CORS

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -36,6 +36,10 @@ module.exports = function () {
         alias: 'ro',
         description: 'Allow only GET requests'
       },
+      'no-cors': {
+        alias: 'nc',
+        description: 'Disable Cross-Origin Resource Sharing'
+      },
       snapshots: {
         alias: 'S',
         description: 'Set snapshots directory',
@@ -58,6 +62,7 @@ module.exports = function () {
     .boolean('watch')
     .boolean('read-only')
     .boolean('quiet')
+    .boolean('no-cors')
     .help('help').alias('help', 'h')
     .version(pkg.version).alias('version', 'v')
     .example('$0 db.json', '')

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -44,7 +44,8 @@ function createApp (source, object, routes, argv) {
 
   var defaultsOpts = {
     logger: !argv.quiet,
-    readOnly: argv.readOnly
+    readOnly: argv.readOnly,
+    noCors: argv.noCors
   }
 
   if (argv.static) {

--- a/src/server/defaults.js
+++ b/src/server/defaults.js
@@ -32,7 +32,9 @@ module.exports = function (opts) {
   }
 
   // Enable CORS for all the requests, including static files
-  arr.push(cors({ origin: true, credentials: true }))
+  if (!opts.noCors) {
+    arr.push(cors({ origin: true, credentials: true }))
+  }
 
   if (process.env.NODE_ENV === 'development') {
     // only use in development

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -53,6 +53,15 @@ describe('cli', function () {
       request.get('/posts').expect(200, done)
     })
 
+    it('should send CORS headers', function (done) {
+      var origin = 'http://example.com'
+
+      request.get('/posts')
+        .set('Origin', origin)
+        .expect('access-control-allow-origin', origin)
+        .expect(200, done)
+    })
+
   })
 
   describe('seed.js', function () {
@@ -136,6 +145,33 @@ describe('cli', function () {
 
     it('should save a snapshot in ../../tmp', function () {
       assert.equal(fs.readdirSync(snapshotsDir).length, 1)
+    })
+
+  })
+
+  describe('db.json --no-cors=true', function () {
+
+    beforeEach(function (done) {
+      child = cli(['fixtures/seed.js', '--no-cors=true'])
+      serverReady(PORT, done)
+    })
+
+    it('should not send Access-Control-Allow-Origin headers', function (done) {
+      var origin = 'http://example.com'
+
+      request.get('/posts')
+        .set('Origin', origin)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) {
+            done(err)
+            return
+          } else if ('access-control-allow-origin' in res.headers) {
+            done(new Error('CORS headers were not excluded from response'))
+          } else {
+            done()
+          }
+        })
     })
 
   })


### PR DESCRIPTION
It is desirable to disable CORS for development purposes in order to
validate same-origin policy and web security concepts. Additionally,
json-server could be used to show proxy concepts.

This change adds a new CLI option `--no-cors` which disables CORS by not
adding the CORS middleware. The change is backwards compatible since the
default behavior, i.e. adding CORS headers, is retained.