### PR TITLE
fix status 404 when use with koa-connect

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -78,6 +78,8 @@ module.exports = function (source) {
     if (!res.locals.data) {
       res.status(404)
       res.locals.data = {}
+    } else {
+      res.status(200)
     }
 
     router.render(req, res)


### PR DESCRIPTION
I have used json-server with koa, and the problem is, statusCode is always `404`.

server.js
```
var koa = require("koa");
var route = require("koa-route");
var express = require("express");
var server = express();
var c2k = require("koa-connect");
var jsonServer = require("json-server");

server.use("/api", jsonServer.router('json-server.json'));

app = koa();
app.use(c2k(server));
app.listen(3000);
```

test with curl
```bash
$ curl -i http://localhost:3000/api/posts
HTTP/1.1 404 Not Found
X-Powered-By: Express
X-Content-Type-Options: nosniff
Content-Type: application/json; charset=utf-8
Content-Length: 51
ETag: W/"33-gAAIDPXQFEM2+C2ZOklPIQ"
Date: Sat, 23 Jan 2016 01:01:25 GMT
Connection: keep-alive

[{"id":1,"content":"foo"},{"id":2,"content":"bar"}]%
```