### PR TITLE
Add section under Extras about alternative ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ json-server db.json
 json-server db.json --static ./static
 ```
 
+### Alternative port
+
+You can start JSON Server on other ports with the `--port` flag:
+
+```bash
+$ json-server --watch db.json --port 3004
+```
+
 ### Access from anywhere
 
 You can access your fake API from anywhere using CORS and JSONP.


### PR DESCRIPTION
As per title. I figured this would be useful, since there are already many things that use port 3000 as the default port.