### PR TITLE
Error message for incorrect export type from database JS file

### DIFF
--- a/src/cli/utils/load.js
+++ b/src/cli/utils/load.js
@@ -16,7 +16,13 @@ module.exports = function (source, cb) {
 
     var filename = path.resolve(source)
     delete require.cache[filename]
-    data = require(filename)()
+    var dataFn = require(filename)
+
+    if (typeof dataFn !== 'function') {
+      throw new Error('The database is a JavaScript file but the export is not a function.')
+    }
+
+    data = dataFn()
     cb(null, data)
 
   } else if (is.JSON(source)) {


### PR DESCRIPTION
This had me stuck momentarily. I was exporting the result of the database function rather than the database function itself, and the error message I was receiving was a little cryptic.

Before:

    TypeError: require(...) is not a function

After:

    Error: The database is a JavaScript file, but the export is not a function.

Let me know if you would like a test written for this or if the message isn't desirable.