### PR TITLE
#wip Make deployable to heroku; then it''ll be truly 30s to start as promised

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -6,6 +6,7 @@ var pkg = require('../../package.json')
 module.exports = function () {
 
   updateNotifier({ pkg: pkg }).notify()
+  var portDefault = process.env.PORT || 3000; // heroku provides the port to bind to
 
   var argv = yargs
     .config('config')


### PR DESCRIPTION
- [ x] bind to proper port
- [] add deploy button to readme
- [] update npm start script to include db.json (please let me know if this can be done in a more elegant way; PROCFILE? I don't know how to use that)