### PR TITLE
fixes example with necessary bodyParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,11 @@ server.get('/echo', function (req, res) {
   res.jsonp(req.query)
 })
 
+// The request body must be parsed before it is edited, or the edit will be ineffective
+var bodyParser = require('body-parser');
+server.use(bodyParser.json({limit: '10mb'}))
+
+// Add a custom middleware that alters the request object
 server.use(function (req, res, next) {
   if (req.method === 'POST') {
     req.body.createdAt = Date.now()


### PR DESCRIPTION
I was following the example in the README that has this middleware.

```
server.use(function (req, res, next) {
  if (req.method === 'POST') {
    req.body.createdAt = Date.now()
  }
  // Continue to JSON Server router
  next()
})
```

The rewrite has no effect on the behaviour of the server. One thing I noticed is that `req.body` was always empty by that time. I noticed that it needed to be parsed before the body editing middleware was set.

This problem might have started to happen after some version of express. I'm using 4.13.4, and the code submitted here works fine for me.
