### PR TITLE
Throw error when DB file is missing or is empty

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 typicode
+Copyright (c) 2016 typicode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -99,6 +99,10 @@ module.exports = function (argv) {
     load(source, function (err, data) {
       if (err) throw err
 
+      if (_.isEmpty(data)) {
+        throw new Error(source + ' is empty or does not exist')
+      }
+
       // Load additional routes
       if (argv.routes) {
         console.log(chalk.gray('  Loading', argv.routes))


### PR DESCRIPTION
When starting the server, if the provided DB file is either empty or not existant an error will be thrown.
