### PR TITLE
Add support for big numbers

### DIFF
--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -17,7 +17,15 @@ function toNative (value) {
     } else if (value === 'true' || value === 'false') {
       return value === 'true'
     } else if (!isNaN(+value)) {
-      return +value
+      var numValue = Number.parseInt(value, 10)
+
+      // If the number is too large (not safe) for
+      // Javascript's Number object, return it as a string
+      if (!Number.isSafeInteger(numValue)) {
+        return '' + value
+      }
+
+      return numValue
     }
   }
   return value


### PR DESCRIPTION
Add support for handling numbers larger than [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).

Before this fix numbers larger than the `Number.MAX_SAFE_INTEGER` were getting the wrong value (most likely to integer overflow).

**NOTE:** I did not manage to write any tests for this as I couldn't get chained requests working. If someone were to take a look at that, that would be great. A valid test case would be a POST request with a big number and then a GET request to see that the correct value is being fetched.
