### PR TITLE
feat(cli): allow assign routes with express.Route() in file JS

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -39,6 +39,17 @@ function createApp (source, object, routes, middlewares, argv) {
 
   let router
 
+  let routerExtras
+  if (is.JS(source)) {
+    routerExtras = object.__router
+    if (routerExtras) {
+      if (object.__db === undefined) {
+        throw new Error('The database is not assign in file JavaScript.')
+      }
+      object = typeof object.__db === 'string' ? require(object.__db) : object.__db
+    }
+  }
+
   try {
     router = jsonServer.router(
       is.JSON(source)
@@ -80,6 +91,15 @@ function createApp (source, object, routes, middlewares, argv) {
 
   router.db._.id = argv.id
   app.db = router.db
+
+  if (routerExtras) {
+    try {
+      routerExtras = routerExtras(router) // force pass router to router facility capture db
+    } catch (e) {}
+
+    app.use(routerExtras)
+  }
+
   app.use(router)
 
   return app

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -43,10 +43,10 @@ function createApp (source, object, routes, middlewares, argv) {
   if (is.JS(source)) {
     routerExtras = object.__router
     if (routerExtras) {
-      if (object.__db === undefined) {
-        throw new Error('The database is not assign in file JavaScript.')
+      if (object.__source === undefined) {
+        throw new Error('Define source in object (object, array, string db.json ...)')
       }
-      object = typeof object.__db === 'string' ? require(object.__db) : object.__db
+      object = typeof object.__source === 'string' ? require(object.__source) : object.__source
     }
   }
 
@@ -94,7 +94,8 @@ function createApp (source, object, routes, middlewares, argv) {
 
   if (routerExtras) {
     try {
-      routerExtras = routerExtras(router) // force pass router to router facility capture db
+      // force assign router to callback this facility to capture db
+      routerExtras = routerExtras(router)
     } catch (e) {}
 
     app.use(routerExtras)


### PR DESCRIPTION
This PR allow building routes custom using express.router() in source file JS

```json-server router.js```

Use case
```javascript
var path = require('path');

module.exports = function() {
	var express = require('express');

	var router = function(router) {
		var expressRouter = express.Router();

		expressRouter.get('/news/me', function(req, res) {
		  var new =  router.db
                           .get('news')
			               .find({ id: 1 })
			               .value();
		  res.json(new);
		});

		return expressRouter;
	}

	return {
		"__source": path.join(__dirname, 'db.json'),
		"__router": router
	}
}
```