### PR TITLE
Added many-to-many support for nested resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Create a `db.json` file
 ```json
 {
   "posts": [
-    { "id": 1, "title": "json-server", "author": "typicode", commentId: [1, 2] }
+    { "id": 1, "title": "json-server", "author": "typicode", "commentId": [1, 2] }
   ],
   "comments": [
     { "id": 1, "body": "some comment", "postId": 1 },

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ Create a `db.json` file
 ```json
 {
   "posts": [
-    { "id": 1, "title": "json-server", "author": "typicode" }
+    { "id": 1, "title": "json-server", "author": "typicode", commentId: [1, 2] }
   ],
   "comments": [
-    { "id": 1, "body": "some comment", "postId": 1 }
+    { "id": 1, "body": "some comment", "postId": 1 },
+    { "id": 2, "body": "some other comment", "postId": 1 }
   ],
   "profile": { "name": "typicode" }
 }

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ You can deploy JSON Server. For example, [JSONPlaceholder](http://jsonplaceholde
 * [Docker JSON Server](https://github.com/clue/docker-json-server)
 * [JSON Server GUI](https://github.com/naholyr/json-server-gui)
 * [JSON file generator](https://github.com/dfsq/json-server-init)
+* [JSON Server extension](https://github.com/maty21/json-server-extension)
 
 ## License
 

--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -7,7 +7,7 @@ module.exports = () => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request query
   function get (req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.query[`${prop}Id`] = req.params.id
+    req.query[`${prop}Id_like`] = `\\b${req.params.id}\\b`
     req.url = `/${req.params.nested}`
     next()
   }
@@ -15,7 +15,7 @@ module.exports = () => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post (req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}Id`] = req.params.id
+    req.body[`${prop}Id_like`] = `\\b${req.params.id}\\b`
     req.url = `/${req.params.nested}`
     next()
   }

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -545,7 +545,7 @@ describe('Server', () => {
         .post('/posts/1/comments')
         .send({body: 'foo'})
         .expect('Content-Type', /json/)
-        .expect({id: 6, postId_like: "\\b1\\b", body: 'foo'})
+        .expect({id: 6, postId_like: '\\b1\\b', body: 'foo'})
         .expect(201, done)
     })
   })

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -545,7 +545,7 @@ describe('Server', () => {
         .post('/posts/1/comments')
         .send({body: 'foo'})
         .expect('Content-Type', /json/)
-        .expect({id: 6, postId: 1, body: 'foo'})
+        .expect({id: 6, postId_like: "\\b1\\b", body: 'foo'})
         .expect(201, done)
     })
   })


### PR DESCRIPTION
Hello,

First at all, thanks for your work.
I've changed some things to enable the many-to-many support for nested resources thanks to regex.

That permits to have nested like this: 

```json
{
  "posts": [
    { "id": 1, "title": "json-server", "author": "typicode", "commentId": [1, 2] }
  ],
  "comments": [
    { "id": 1, "body": "some comment", "postId": 1 },
    { "id": 2, "body": "some other comment", "postId": 1 }
  ],
  "profile": { "name": "typicode" }
}
```

Instead of simply that before:
```json
{
  "posts": [
    { "id": 1, "title": "json-server", "author": "typicode", "commentId": 1 }
  ],
  "comments": [
    { "id": 1, "body": "some comment", "postId": 1 },
    { "id": 2, "body": "some other comment", "postId": 1 }
  ],
  "profile": { "name": "typicode" }
}
```

I think this feature could be really interesting for the application :) 
If need some changes or if something is not correct, don't hesitate to tell me.