### PR TITLE
Added support for multiple fields sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ GET /posts?_sort=views&_order=DESC
 GET /posts/1/comments?_sort=votes&_order=ASC
 ```
 
+For multiple fields, use the following format:
+
+```
+GET /posts?_sort=user,views&_order=desc,asc
+```
+
+
 ### Slice
 
 Add `_start` and `_end` or `_limit` (an `X-Total-Count` header is included in the response)

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -141,14 +141,18 @@ module.exports = (db, name) => {
 
     // Sort
     if (_sort) {
-      _order = _order || 'ASC'
-
-      chain = chain.sortBy(function (element) {
-        return _.get(element, _sort)
-      })
-
-      if (_order === 'DESC') {
-        chain = chain.reverse()
+      if (_sort.match(/,/)) {
+        const _sortSet = _sort.split(/,/)
+        const _orderSet = _order.split(/,/)
+        chain = chain.orderBy(_sortSet, _orderSet)
+      } else {
+        _order = _order || 'ASC'
+        chain = chain.sortBy(function (element) {
+          return _.get(element, _sort)
+        })
+        if (_order === 'DESC') {
+          chain = chain.reverse()
+        }
       }
     }
 

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -42,6 +42,18 @@ describe('Server', () => {
       { id: 5, body: 'quux', published: false, postId: 2, userId: 1 }
     ]
 
+    db.buyers = [
+      { id: 1, name: 'Aileen', country: 'Colombia', total: 100 },
+      { id: 2, name: 'Barney', country: 'Colombia', total: 200 },
+      { id: 3, name: 'Carley', country: 'Colombia', total: 300 },
+      { id: 4, name: 'Daniel', country: 'Belize', total: 30 },
+      { id: 5, name: 'Ellen', country: 'Belize', total: 20 },
+      { id: 6, name: 'Frank', country: 'Belize', total: 10 },
+      { id: 7, name: 'Grace', country: 'Argentina', total: 1 },
+      { id: 8, name: 'Henry', country: 'Argentina', total: 2 },
+      { id: 9, name: 'Isabelle', country: 'Argentina', total: 3 }
+    ]
+
     db.refs = [
       { id: 'abcd-1234', url: 'http://example.com', postId: 1, userId: 1 }
     ]
@@ -257,6 +269,18 @@ describe('Server', () => {
         .get('/nested?_sort=resource.name')
         .expect('Content-Type', /json/)
         .expect([ db.nested[1], db.nested[0], db.nested[2] ])
+        .expect(200)
+    ))
+
+    it('should sort on multiple fields', () => (
+      request(server)
+        .get('/buyers?_sort=country,total&_order=asc,desc')
+        .expect('Content-Type', /json/)
+        .expect([
+          db.buyers[8], db.buyers[7], db.buyers[6],
+          db.buyers[3], db.buyers[4], db.buyers[5],
+          db.buyers[2], db.buyers[1], db.buyers[0]
+        ])
         .expect(200)
     ))
   })


### PR DESCRIPTION
Multiple field sorting, extending current project spec.

Allows multiple fields to be specified using a comma-separated list:

```
GET /posts?_sort=user,views&_order=desc,asc
```

Which would sort by user descending, and then by views ascending.

Wanted to adhere to my favorite best practice list [Best Practices for Designing a Pragmatic RESTful API](http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api) but decided to build on current format.

Please share any thoughts,

Regards,

GM
