### PR TITLE
Throw error on bad POST request

### DIFF
--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -232,18 +232,23 @@ module.exports = (db, name) => {
 
   // POST /name
   function create (req, res, next) {
-    const resource = db
-      .get(name)
-      .insert(req.body)
-      .value()
+    if (_.isArray(req.body)) {
+      res.status(400)
+      res.send({error: 'The body sent was not JSON'})
+    } else {
+      const resource = db
+        .get(name)
+        .insert(req.body)
+        .value()
 
-    res.setHeader('Access-Control-Expose-Headers', 'Location')
-    res.location(`${getFullURL(req)}/${resource.id}`)
+      res.setHeader('Access-Control-Expose-Headers', 'Location')
+      res.location(`${getFullURL(req)}/${resource.id}`)
 
-    res.status(201)
-    res.locals.data = resource
+      res.status(201)
+      res.locals.data = resource
 
-    next()
+      next()
+    }
   }
 
   // PUT /name/:id

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -547,6 +547,16 @@ describe('Server', () => {
       assert.equal(db.posts.length, 3)
     })
 
+    it('should respond with error when sending an array as the body', async () => {
+      await request(server)
+        .post('/posts')
+        .send([{body: 'foo', booleanValue: true, integerValue: 1}])
+        .expect('Content-Type', /json/)
+        .expect({error: 'The body sent was not JSON'})
+        .expect(400)
+      assert.equal(db.posts.length, 2)
+    })
+
     it('should support x-www-form-urlencoded', async () => {
       await request(server)
         .post('/posts')


### PR DESCRIPTION
Addresses #547.

The other possible way to go here is to accept either:
- just the first item in an array when posting, so that ```[{foo:'bar'}]``` would still insert that object
- allow arrays of objects to be inserted en-masse

I left ```singular``` untouched because I could foresee situations where someone might want an array as the value of a singular property.