### PR TITLE
Disable logging for static content requests by loading the logger middleware after the static middleware

### DIFF
--- a/src/server/defaults.js
+++ b/src/server/defaults.js
@@ -21,16 +21,6 @@ module.exports = function(opts) {
     arr.push(compression())
   }
 
-  // Logger
-  if (opts.logger) {
-    arr.push(
-      logger('dev', {
-        skip: req =>
-          process.env.NODE_ENV === 'test' || req.path === '/favicon.ico'
-      })
-    )
-  }
-
   // Enable CORS for all the requests, including static files
   if (!opts.noCors) {
     arr.push(cors({ origin: true, credentials: true }))
@@ -43,6 +33,16 @@ module.exports = function(opts) {
 
   // Serve static files
   arr.push(express.static(opts.static))
+
+  // Logger
+  if (opts.logger) {
+    arr.push(
+      logger('dev', {
+        skip: req =>
+          process.env.NODE_ENV === 'test' || req.path === '/favicon.ico'
+      })
+    )
+  }
 
   // No cache for IE
   // https://support.microsoft.com/en-us/kb/234067


### PR DESCRIPTION
As you can see from the below screenshot, express is logging all static file requests. This seems to be outside of the scope of json-server, particularly if you're already using something like BrowserSync. This PR disables logging for static content requests by loading the logger middleware after the static middleware.

<img width="297" alt="screen shot 2017-07-12 at 12 35 38 pm" src="https://user-images.githubusercontent.com/16327472/28128715-a483b344-66fe-11e7-8737-a757265b7723.png">

**From the express docs:** 

Disable logging for static content requests by loading the logger middleware after the static middleware:

```
app.use(express.static(__dirname + '/public'));
app.use(logger());
```

By doing this, it now only logs the json-server API requests, instead of ALL requests.