### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,6 +3345,11 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nanoid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-0.2.2.tgz",
+      "integrity": "sha512-GHoRrvNEKiwdkwQ/enKL8AhQkkrBC/2KxMZkDvQzp8OtkpX8ZAmoYJWFVl7l8F2+HcEJUfdg21Ab2wXXfrvACQ=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4201,11 +4206,6 @@
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
       }
-    },
-    "shortid": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
-      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE="
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "lowdb": "^0.15.0",
     "method-override": "^2.1.2",
     "morgan": "^1.3.1",
+    "nanoid": "^0.2.2",
     "object-assign": "^4.0.1",
     "please-upgrade-node": "^3.0.1",
     "pluralize": "^3.0.0",
     "request": "^2.72.0",
     "server-destroy": "^1.0.1",
-    "shortid": "^2.2.6",
     "update-notifier": "^1.0.2",
     "yargs": "^6.0.0"
   },

--- a/src/server/mixins.js
+++ b/src/server/mixins.js
@@ -1,4 +1,4 @@
-const shortid = require('shortid')
+const nanoid = require('nanoid')
 const pluralize = require('pluralize')
 
 module.exports = {
@@ -48,7 +48,7 @@ function createId(coll) {
     let id = _(coll).maxBy(idProperty)[idProperty]
 
     // Increment integer id or generate string id
-    return _.isFinite(id) ? ++id : shortid.generate()
+    return _.isFinite(id) ? ++id : nanoid(7)
   }
 }
 


### PR DESCRIPTION
Hi. Thanks for the great project.

What do you think of replacing `shortid` to [`nanoid`](https://github.com/ai/nanoid) (without big changes for users). Benefits:

1. `shortid` is not maintained anymore (and issue tracker has many important issues). I tried to took maintenance, but found that I can’t fix `shortid` with keeping API.
2. `shortid` has problem with random generator ([issue](https://github.com/dylang/shortid/issues/70)) and ID uniformity ([issue](https://github.com/dylang/shortid/issues/85)). `nanoid` use hardware random generator and has special uniformity tests ([docs](https://github.com/ai/nanoid#security)).
3. `shortid` has the problem with `-` symbol in the end of URL on some Android app ([issue](https://github.com/dylang/shortid/issues/96)). `nanoid` uses safe `~` instead of `-`. If it is not relevant to this project, I can replace `~` → `-` back to keep 100% old API.
4. `nanoid` is [10x times faster](https://github.com/ai/nanoid#benchmark) than `shortid`.

@ typicode what do you think?