### PR TITLE
fix(build): newline after each call in a method chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-env": "^1.3.2",
     "babel-register": "^6.16.3",
     "cross-env": "^2.0.1",
-    "eslint": "^3.19.0",
+    "eslint": "^4.9.0",
     "eslint-config-prettier": "^2.3.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.6.1",

--- a/src/server/mixins.js
+++ b/src/server/mixins.js
@@ -67,7 +67,12 @@ function deepQuery(value, q) {
           return true
         }
       }
-    } else if (value.toString().toLowerCase().indexOf(q) !== -1) {
+    } else if (
+      value
+        .toString()
+        .toLowerCase()
+        .indexOf(q) !== -1
+    ) {
       return true
     }
   }

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -228,7 +228,10 @@ module.exports = (db, name, opts) => {
   function show(req, res, next) {
     const _embed = req.query._embed
     const _expand = req.query._expand
-    const resource = db.get(name).getById(req.params.id).value()
+    const resource = db
+      .get(name)
+      .getById(req.params.id)
+      .value()
 
     if (resource) {
       // Clone resource to avoid making changes to the underlying object
@@ -250,7 +253,10 @@ module.exports = (db, name, opts) => {
 
   // POST /name
   function create(req, res, next) {
-    const resource = db.get(name).insert(req.body).value()
+    const resource = db
+      .get(name)
+      .insert(req.body)
+      .value()
 
     res.setHeader('Access-Control-Expose-Headers', 'Location')
     res.location(`${getFullURL(req)}/${resource.id}`)
@@ -283,14 +289,20 @@ module.exports = (db, name, opts) => {
 
   // DELETE /name/:id
   function destroy(req, res, next) {
-    const resource = db.get(name).removeById(req.params.id).value()
+    const resource = db
+      .get(name)
+      .removeById(req.params.id)
+      .value()
 
     // Remove dependents documents
     console.log({ opts })
     const removable = db._.getRemovable(db.getState(), opts)
     console.log(removable)
     removable.forEach(item => {
-      db.get(item.name).removeById(item.id).value()
+      db
+        .get(item.name)
+        .removeById(item.id)
+        .value()
     })
 
     if (resource) {
@@ -302,7 +314,10 @@ module.exports = (db, name, opts) => {
 
   const w = write(db)
 
-  router.route('/').get(list).post(create, w)
+  router
+    .route('/')
+    .get(list)
+    .post(create, w)
 
   router
     .route('/:id')

--- a/src/server/router/singular.js
+++ b/src/server/router/singular.js
@@ -25,7 +25,10 @@ module.exports = (db, name) => {
     if (req.method === 'PUT') {
       db.set(name, req.body).value()
     } else {
-      db.get(name).assign(req.body).value()
+      db
+        .get(name)
+        .assign(req.body)
+        .value()
     }
 
     res.locals.data = db.get(name).value()
@@ -34,7 +37,12 @@ module.exports = (db, name) => {
 
   const w = write(db)
 
-  router.route('/').get(show).post(create, w).put(update, w).patch(update, w)
+  router
+    .route('/')
+    .get(show)
+    .post(create, w)
+    .put(update, w)
+    .patch(update, w)
 
   return router
 }

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -76,13 +76,16 @@ describe('cli', () => {
     })
 
     it('should update JSON file', done => {
-      request.post('/posts').send({ title: 'hello' }).end(() => {
-        setTimeout(() => {
-          const str = fs.readFileSync(dbFile, 'utf8')
-          assert(str.indexOf('hello') !== -1)
-          done()
-        }, 1000)
-      })
+      request
+        .post('/posts')
+        .send({ title: 'hello' })
+        .end(() => {
+          setTimeout(() => {
+            const str = fs.readFileSync(dbFile, 'utf8')
+            assert(str.indexOf('hello') !== -1)
+            done()
+          }, 1000)
+        })
     })
   })
 
@@ -170,7 +173,10 @@ describe('cli', () => {
     })
 
     it('should have post body in middleware', done => {
-      request.post('/posts').send({ name: 'test' }).expect('name', 'test', done)
+      request
+        .post('/posts')
+        .send({ name: 'test' })
+        .expect('name', 'test', done)
     })
   })
 
@@ -246,15 +252,18 @@ describe('cli', () => {
     })
 
     it('should not set Content-Encoding to gzip', done => {
-      request.get('/posts').expect(200).end(function(err, res) {
-        if (err) {
-          done(err)
-        } else if ('content-encoding' in res.headers) {
-          done(new Error('Content-Encoding is set to gzip'))
-        } else {
-          done()
-        }
-      })
+      request
+        .get('/posts')
+        .expect(200)
+        .end(function(err, res) {
+          if (err) {
+            done(err)
+          } else if ('content-encoding' in res.headers) {
+            done(new Error('Content-Encoding is set to gzip'))
+          } else {
+            done()
+          }
+        })
     })
   })
 

--- a/test/server/plural-with-custom-foreign-key.js
+++ b/test/server/plural-with-custom-foreign-key.js
@@ -106,7 +106,10 @@ describe('Server with custom foreign key', () => {
 
   describe('DELETE /:resource/:id', () => {
     it('should respond with empty data, destroy resource and dependent resources', async () => {
-      await request(server).del('/posts/1').expect({}).expect(200)
+      await request(server)
+        .del('/posts/1')
+        .expect({})
+        .expect(200)
       assert.equal(db.posts.length, 1)
       assert.equal(db.comments.length, 1)
     })

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -111,7 +111,9 @@ describe('Server', () => {
         .expect(200))
 
     it('should respond with 404 if resource is not found', () =>
-      request(server).get('/undefined').expect(404))
+      request(server)
+        .get('/undefined')
+        .expect(404))
   })
 
   describe('GET /:resource?attr=&attr=', () => {
@@ -590,7 +592,10 @@ describe('Server', () => {
 
   describe('DELETE /:resource/:id', () => {
     it('should respond with empty data, destroy resource and dependent resources', async () => {
-      await request(server).del('/posts/1').expect({}).expect(200)
+      await request(server)
+        .del('/posts/1')
+        .expect({})
+        .expect(200)
       assert.equal(db.posts.length, 1)
       assert.equal(db.comments.length, 3)
     })
@@ -646,25 +651,37 @@ describe('Server', () => {
 
   describe('Rewriter', () => {
     it('should rewrite using prefix', () =>
-      request(server).get('/api/posts/1').expect(db.posts[0]))
+      request(server)
+        .get('/api/posts/1')
+        .expect(db.posts[0]))
 
     it('should rewrite using params', () =>
-      request(server).get('/blog/posts/1/show').expect(db.posts[0]))
+      request(server)
+        .get('/blog/posts/1/show')
+        .expect(db.posts[0]))
 
     it('should rewrite using query without params', () => {
       const expectedPost = _.cloneDeep(db.posts[0])
       expectedPost.comments = [db.comments[0], db.comments[1]]
-      return request(server).get('/firstpostwithcomments').expect(expectedPost)
+      return request(server)
+        .get('/firstpostwithcomments')
+        .expect(expectedPost)
     })
 
     it('should rewrite using params and query', () =>
-      request(server).get('/comments/special/1-quux').expect([db.comments[4]]))
+      request(server)
+        .get('/comments/special/1-quux')
+        .expect([db.comments[4]]))
 
     it('should rewrite query params', () =>
-      request(server).get('/articles?_id=1').expect(db.posts[0]))
+      request(server)
+        .get('/articles?_id=1')
+        .expect(db.posts[0]))
 
     it('should expose routes', () =>
-      request(server).get('/__rules').expect(rewriterRules))
+      request(server)
+        .get('/__rules')
+        .expect(rewriterRules))
   })
 
   describe('router.render', () => {

--- a/test/server/singular.js
+++ b/test/server/singular.js
@@ -22,20 +22,31 @@ describe('Server', () => {
 
   describe('GET /:resource', () => {
     it('should respond with corresponding resource', () =>
-      request(server).get('/user').expect(db.user).expect(200))
+      request(server)
+        .get('/user')
+        .expect(db.user)
+        .expect(200))
   })
 
   describe('POST /:resource', () => {
     it('should create resource', () => {
       const user = { name: 'bar' }
-      return request(server).post('/user').send(user).expect(user).expect(201)
+      return request(server)
+        .post('/user')
+        .send(user)
+        .expect(user)
+        .expect(201)
     })
   })
 
   describe('PUT /:resource', () => {
     it('should update resource', () => {
       const user = { name: 'bar' }
-      return request(server).put('/user').send(user).expect(user).expect(200)
+      return request(server)
+        .put('/user')
+        .send(user)
+        .expect(user)
+        .expect(200)
     })
   })
 


### PR DESCRIPTION
Since prettier prints chained calls in new line, eslint fails when used with prettier. 
PR for the same in prettier https://github.com/prettier/prettier/pull/2673

If there is an option to disable this prettier rule when using with eslint I guess we can go for that.
