### PR TITLE
Fixed missing URL to localhost in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Start JSON Server
 $ json-server --watch db.json
 ```
 
-Now if you go to [http://localhost:3000/posts/1](), you'll get
+Now if you go to [http://localhost:3000/posts/1](http://localhost:3000/posts/1), you'll get
 
 ```json
 { "id": 1, "title": "json-server", "author": "typicode" }


### PR DESCRIPTION
Every time I read through the readme.md to quickstart the project I clicked the link "http://localhost:3000/posts/1" mentioned in one of the steps:

> Now if you go to http://localhost:3000/posts/1, you'll get

I expected that it would take me to the working local server. Instead of that, to my confusion, it took me to the github 404 page (https://github.com/typicode/json-server/blob/master).

Considering that other people I've encountered were surprised by the same thing I came to the conclusion that it's not only my quirk and decided to suggest a quickfix here.