### PR TITLE
added support for _delay in query string to delay response of request on per request basis

### DIFF
--- a/src/server/router/delay.js
+++ b/src/server/router/delay.js
@@ -1,9 +1,11 @@
 const pause = require('connect-pause')
 
 module.exports = function delay(req, res, next) {
-  // NOTE: for some reason unknown to me, if the default is 0, the tests seems to add 2 seconds 
+  // NOTE: for some reason unknown to me, if the default is 0, the tests seems to add 2 seconds
   // NOTE: to each test, a default value of 1 does not seem to be effected by that issue
-  const _delay = !isNaN(parseFloat(req.query._delay)) ? parseFloat(req.query._delay) : 1
+  const _delay = !isNaN(parseFloat(req.query._delay))
+    ? parseFloat(req.query._delay)
+    : 1
   delete req.query._delay
   pause(_delay)(req, res, next)
 }

--- a/src/server/router/delay.js
+++ b/src/server/router/delay.js
@@ -1,0 +1,9 @@
+const pause = require('connect-pause')
+
+module.exports = function delay(req, res, next) {
+  // NOTE: for some reason unknown to me, if the default is 0, the tests seems to add 2 seconds 
+  // NOTE: to each test, a default value of 1 does not seem to be effected by that issue
+  const _delay = !isNaN(parseFloat(req.query._delay)) ? parseFloat(req.query._delay) : 1
+  delete req.query._delay
+  pause(_delay)(req, res, next)
+}

--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const pluralize = require('pluralize')
+const delay = require('./delay')
 
 module.exports = opts => {
   const router = express.Router()
+  router.use(delay)
 
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request query
   function get(req, res, next) {

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -4,10 +4,12 @@ const pluralize = require('pluralize')
 const write = require('./write')
 const getFullURL = require('./get-full-url')
 const utils = require('../utils')
+const delay = require('./delay')
 
 module.exports = (db, name, opts) => {
   // Create router
   const router = express.Router()
+  router.use(delay)
 
   // Embed function used in GET /name and GET /name/id
   function embed(resource, e) {

--- a/src/server/router/singular.js
+++ b/src/server/router/singular.js
@@ -1,9 +1,11 @@
 const express = require('express')
 const write = require('./write')
 const getFullURL = require('./get-full-url')
+const delay = require('./delay')
 
 module.exports = (db, name) => {
   const router = express.Router()
+  router.use(delay)
 
   function show(req, res, next) {
     res.locals.data = db.get(name).value()

--- a/test/server/plural.js
+++ b/test/server/plural.js
@@ -501,6 +501,18 @@ describe('Server', () => {
     })
   })
 
+  describe('GET /:resource>_delay=', () => {
+    it('should delay response', done => {
+      const start = new Date()
+      request(server)
+        .get('/posts?_delay=1100')
+        .expect(200, function(err) {
+          const end = new Date()
+          done(end - start > 1000 ? err : new Error("Request wasn't delayed"))
+        })
+    })
+  })
+
   describe('POST /:resource', () => {
     it('should respond with json, create a resource and increment id', async () => {
       await request(server)
@@ -546,6 +558,19 @@ describe('Server', () => {
         .expect(201))
   })
 
+  describe('POST /:resource?_delay=', () => {
+    it('should delay response', done => {
+      const start = new Date()
+      request(server)
+        .post('/posts?_delay=1100')
+        .send({ body: 'foo', booleanValue: true, integerValue: 1 })
+        .expect(201, function(err) {
+          const end = new Date()
+          done(end - start > 1000 ? err : new Error("Request wasn't delayed"))
+        })
+    })
+  })
+
   describe('PUT /:resource/:id', () => {
     it('should respond with json and replace resource', async () => {
       const post = { id: 1, booleanValue: true, integerValue: 1 }
@@ -573,6 +598,20 @@ describe('Server', () => {
         .expect(404))
   })
 
+  describe('PUT /:resource:id?_delay=', () => {
+    it('should delay response', done => {
+      const start = new Date()
+      request(server)
+        .put('/posts/1?_delay=1100')
+        .set('Accept', 'application/json')
+        .send({ id: 1, booleanValue: true, integerValue: 1 })
+        .expect(200, function(err) {
+          const end = new Date()
+          done(end - start > 1000 ? err : new Error("Request wasn't delayed"))
+        })
+    })
+  })
+
   describe('PATCH /:resource/:id', () => {
     it('should respond with json and update resource', async () => {
       const partial = { body: 'bar' }
@@ -597,6 +636,20 @@ describe('Server', () => {
         .expect(404))
   })
 
+  describe('PATCH /:resource:id?_delay=', () => {
+    it('should delay response', done => {
+      const start = new Date()
+      request(server)
+        .patch('/posts/1?_delay=1100')
+        .send({ body: 'bar' })
+        .send({ id: 1, booleanValue: true, integerValue: 1 })
+        .expect(200, function(err) {
+          const end = new Date()
+          done(end - start > 1000 ? err : new Error("Request wasn't delayed"))
+        })
+    })
+  })
+
   describe('DELETE /:resource/:id', () => {
     it('should respond with empty data, destroy resource and dependent resources', async () => {
       await request(server)
@@ -613,6 +666,19 @@ describe('Server', () => {
         .expect('Content-Type', /json/)
         .expect({})
         .expect(404))
+  })
+
+  describe('DELETE /:resource:id?_delay=', () => {
+    it('should delay response', done => {
+      const start = new Date()
+      request(server)
+        .del('/posts/1?_delay=1100')
+        .send({ id: 1, booleanValue: true, integerValue: 1 })
+        .expect(200, function(err) {
+          const end = new Date()
+          done(end - start > 1000 ? err : new Error("Request wasn't delayed"))
+        })
+    })
   })
 
   describe('Static routes', () => {


### PR DESCRIPTION
This change makes it possible to delay the response of the request on a per request basis by passing in a `_delay` query string parameter and delaying the execution by that using `setTimeout()`. This was needed for me as I often want different requests to have different delays which is not possible with the global delay on server setup and figured it would be helpful for other people.

This delay would be added to whatever global delay was set to when starting the server.

All tests pass however their seems to be pre-existing eslint issue (not introduce by these changes).