### PR TITLE
Fixed eslint errors in Tests

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -66,10 +66,9 @@ module.exports = (source, opts = { foreignKeySuffix: 'Id' }) => {
       }
 
       const msg =
-        `Type of "${key}" (${typeof value}) ${_.isObject(source)
-          ? ''
-          : `in ${source}`} is not supported. ` +
-        `Use objects or arrays of objects.`
+        `Type of "${key}" (${typeof value}) ${
+          _.isObject(source) ? '' : `in ${source}`
+        } is not supported. ` + `Use objects or arrays of objects.`
 
       throw new Error(msg)
     })

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -65,10 +65,14 @@ module.exports = (source, opts = { foreignKeySuffix: 'Id' }) => {
         return
       }
 
+      var sourceMessage = ''
+      if (!_.isObject(source)) {
+        sourceMessage = `in ${source}`
+      }
+
       const msg =
-        `Type of "${key}" (${typeof value}) ${
-          _.isObject(source) ? '' : `in ${source}`
-        } is not supported. ` + `Use objects or arrays of objects.`
+        `Type of "${key}" (${typeof value}) ${sourceMessage} is not supported. ` +
+        `Use objects or arrays of objects.`
 
       throw new Error(msg)
     })


### PR DESCRIPTION
I refactored the error message built during routes creation.
Previously tests were failing with Node 4, but now it is ok for both `stable` and `4`.