### PR TITLE
Fix remote url loader not working

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -65,10 +65,13 @@ module.exports = (source, opts = { foreignKeySuffix: 'Id' }) => {
         return
       }
 
+      var sourceMessage = ''
+      if (!_.isObject(source)) {
+        sourceMessage = `in ${source}`
+      }
+
       const msg =
-        `Type of "${key}" (${typeof value}) ${_.isObject(source)
-          ? ''
-          : `in ${source}`} is not supported. ` +
+        `Type of "${key}" (${typeof value}) ${sourceMessage} is not supported. ` +
         `Use objects or arrays of objects.`
 
       throw new Error(msg)


### PR DESCRIPTION
For some reason the request module is not working properly so I used the native http/https module to load a remote URL. 

Also eslint is not happy about some things so I incorporated fix of @christianascone on pull request #728 with this. If there is a cleaner way to merge our pull request, let me know.