### PR TITLE
Update cors origin

### DIFF
--- a/src/server/defaults.js
+++ b/src/server/defaults.js
@@ -24,7 +24,7 @@ module.exports = function(opts) {
 
   // Enable CORS for all the requests, including static files
   if (!opts.noCors) {
-    arr.push(cors({ origin: true, credentials: true }))
+    arr.push(cors({ origin: '*', credentials: true }))
   }
 
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Hi! Thanks for the awesome package. I'm trying to send a request to the endpoint `http://localhost:3000/users` created by `json-server` and getting the following error related to CORS: 

> Failed to load http://localhost:3000/users: The 'Access-Control-Allow-Origin' header has a value 'null' that is not equal to the supplied origin. Origin 'null' is therefore not allowed access. Have the server send the header with a valid value, or, if an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

I have the same error when trying to send a request to https://jsonplaceholder.typicode.com. As it seems to me, CORS middleware should be configured by a specific origin.