### PR TITLE
DELETE request: only remove dependent document + add no cascade flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Also when doing requests, it's good to know that:
 - Your request body JSON should be object enclosed, just like the GET output. (for example `{"name": "Foobar"}`)
 - Id values are not mutable. Any `id` value in the body of your PUT or PATCH request wil be ignored. Only a value set in a POST request wil be respected, but only if not already taken.
 - A POST, PUT or PATCH request should include a `Content-Type: application/json` header to use the JSON in the request body. Otherwise it will result in a 200 OK but without changes being made to the data.
+- DELETE requests will look for dependent documents, and will remove them as well. That means that for the previous `db.json` file, a `DELETE /posts/1` would also delete the dependent comment (with `postId: 1`). You can disable this behavior by raising the 'no-delete-cascade' flag. See [CLI usage](#cli-usage).
 
 ## Install
 
@@ -369,6 +370,7 @@ Options:
   --static, -s       Set static files directory
   --read-only, --ro  Allow only GET requests                           [boolean]
   --no-cors, --nc    Disable Cross-Origin Resource Sharing             [boolean]
+  --no-delete-cascade, --ndc    Disable delete cacade behavior         [boolean]
   --no-gzip, --ng    Disable GZIP Content-Encoding                     [boolean]
   --snapshots, -S    Set snapshots directory                      [default: "."]
   --delay, -d        Add delay to responses (ms)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -45,6 +45,10 @@ module.exports = function() {
         alias: 'nc',
         description: 'Disable Cross-Origin Resource Sharing'
       },
+      'no-delete-cascade': {
+        alias: 'ndc',
+        description: 'Disable delete cascade behavior'
+      },
       'no-gzip': {
         alias: 'ng',
         description: 'Disable GZIP Content-Encoding'
@@ -82,6 +86,7 @@ module.exports = function() {
     .boolean('read-only')
     .boolean('quiet')
     .boolean('no-cors')
+    .boolean('no-delete-cascade')
     .boolean('no-gzip')
     .help('help')
     .alias('help', 'h')

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -40,12 +40,12 @@ function createApp(source, object, routes, middlewares, argv) {
 
   let router
 
-  const { foreignKeySuffix } = argv
+  const { foreignKeySuffix, noDeleteCascade } = argv
   try {
-    router = jsonServer.router(
-      is.JSON(source) ? source : object,
-      foreignKeySuffix ? { foreignKeySuffix } : undefined
-    )
+    router = jsonServer.router(is.JSON(source) ? source : object, {
+      foreignKeySuffix,
+      noDeleteCascade
+    })
   } catch (e) {
     console.log()
     console.error(chalk.red(e.message.replace(/^/gm, '  ')))

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -66,10 +66,9 @@ module.exports = (source, opts = { foreignKeySuffix: 'Id' }) => {
       }
 
       const msg =
-        `Type of "${key}" (${typeof value}) ${_.isObject(source)
-          ? ''
-          : `in ${source}`} is not supported. ` +
-        `Use objects or arrays of objects.`
+        `Type of "${key}" (${typeof value}) ${
+          _.isObject(source) ? '' : `in ${source}`
+        } is not supported. ` + `Use objects or arrays of objects.`
 
       throw new Error(msg)
     })

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -296,14 +296,17 @@ module.exports = (db, name, opts) => {
       .removeById(req.params.id)
       .value()
 
-    // Remove dependents documents
-    const removable = db._.getRemovable(db.getState(), opts)
-    removable.forEach(item => {
-      db
-        .get(item.name)
-        .removeById(item.id)
-        .value()
-    })
+    if (!opts.noDeleteCascade) {
+      // Remove dependents documents
+      const prop = `${pluralize.singular(name)}${opts.foreignKeySuffix}`
+      const dependents = db._.getDependents(db.getState(), prop, req.params.id)
+      dependents.forEach(item => {
+        db
+          .get(item.name)
+          .removeById(item.id)
+          .value()
+      })
+    }
 
     if (resource) {
       res.locals.data = {}

--- a/test/server/mixins.js
+++ b/test/server/mixins.js
@@ -24,23 +24,28 @@ describe('mixins', () => {
     }
   })
 
-  describe('getRemovable', () => {
-    it('should return removable documents', () => {
+  describe('getDependents', () => {
+    it('should return dependent documents', () => {
       const expected = [
         { name: 'comments', id: 2 },
         { name: 'comments', id: 3 }
       ]
 
-      assert.deepEqual(_.getRemovable(db, { foreignKeySuffix: 'Id' }), expected)
+      assert.deepEqual(_.getDependents(db, 'postId', 2), expected)
     })
 
-    it('should support custom foreignKeySuffix', () => {
+    it('should return dependent documents (type insensitive)', () => {
       const expected = [
         { name: 'comments', id: 2 },
         { name: 'comments', id: 3 }
       ]
 
-      assert.deepEqual(_.getRemovable(db, { foreignKeySuffix: 'Id' }), expected)
+      assert.deepEqual(_.getDependents(db, 'postId', '2'), expected)
+    })
+
+    it('should not return irrelevant dead documents', () => {
+      const expected = [{ name: 'comments', id: 1 }]
+      assert.deepEqual(_.getDependents(db, 'postId', 1), expected)
     })
   })
 


### PR DESCRIPTION
Changed the DELETE method cascade functionality so it would only delete documents which are dependent on the deleted document.

Also added a new flag to disable this cascading delete: "--no-delete-cascade"

Updated README and tests.

This addresses #725, #721, #578, #545 