### PR TITLE
Don't force host running on 'localhost' when using '0.0.0.0'.

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -11,7 +11,7 @@ const example = require('./example.json')
 const jsonServer = require('../server')
 
 function prettyPrint(argv, object, rules) {
-  const host = argv.host === '0.0.0.0' ? 'localhost' : argv.host
+  const host = argv.host === argv.host
   const port = argv.port
   const root = `http://${host}:${port}`
 

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -11,7 +11,7 @@ const example = require('./example.json')
 const jsonServer = require('../server')
 
 function prettyPrint(argv, object, rules) {
-  const host = argv.host === argv.host
+  const host = argv.host
   const port = argv.port
   const root = `http://${host}:${port}`
 


### PR DESCRIPTION
Sometimes we want the server to run in the host "0.0.0.0" to expose it in a local network. Forcing it to "localhost" prevents that flexibility.