### PR TITLE
include support for many to many

### DIFF
--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -142,6 +142,8 @@ module.exports = (db, name, opts) => {
                 return value !== elementValue.toString()
               } else if (isLike) {
                 return new RegExp(value, 'i').test(elementValue.toString())
+              } else if(Array.isArray(elementValue)) {
+                return _.includes(_.map(elementValue, el => el.toString()), value)
               } else {
                 return value === elementValue.toString()
               }


### PR DESCRIPTION
another solution for [this issue](https://github.com/typicode/json-server/issues/805)

it can support `\posts?tags_in=sometag`  or `\posts?tags_nin=sometag`  and `tags\sometag\posts`  but it can't limit search to same as previous