### PR TITLE
Show proper error for PORT in use

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -132,6 +132,20 @@ module.exports = function(argv) {
 
       // Display server informations
       prettyPrint(argv, db.getState(), routes)
+
+      // Catch and handle any error occurring in the server process
+      process.on('uncaughtException', error => {
+        if (error.errno === 'EADDRINUSE')
+          console.log(
+            chalk.red(
+              `Cannot bind to the port ${
+                error.port
+              }. Specify some other port number either through --port argument or through the json-server.json configuration file`
+            )
+          )
+        else console.log('Some error occurred', error)
+        process.exit(1)
+      })
     })
   }
 


### PR DESCRIPTION
The PR aims to address the following issues:
* Show readable error message for port already used by some other process.
* Also, catch any other unCaughtException thrown by the process. This can be extended to handle each specific exceptions in the future.

Signed-off-by: VighneshKSP <ksp.vighnesh@gmail.com>