### PR TITLE
Expose program config (when used on cli)

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -72,6 +72,7 @@ function createApp(db, routes, middlewares, argv) {
 
   router.db._.id = argv.id
   app.db = router.db
+  app.config = _.omit(argv, ['_', '$0'])
   app.use(router)
 
   return app


### PR DESCRIPTION
My proposal is to expose a __config__ property together with the [db property](https://github.com/typicode/json-server/blob/master/src/cli/run.js#L74) on the express application created by json-server cli with the content of the configuration parsed by yargs, __useful in particular__ when using the `-c, --config` flag since yargs [will set all properties as arguments](https://github.com/yargs/yargs/blob/master/docs/api.md#configobject), this allow plugins to have their namespace of options in the config file without any other changes and it will open many customization possibilities to plugins and third party modules based on json-server.

For example take this [json-server plugin](https://github.com/jeremyben/json-server-auth) which right now expose [middlewares](https://github.com/jeremyben/json-server-auth/blob/master/src/index.ts) (to hook into json-server cli) with this update the user can define for example a __auth__ property in the configuration file:

```json
{
  "port": 3001,
  "auth:  {
    jwtExpiration: '1h',
    // more plugin config
  }
}
```

And this configuration can be later accessed, for example in the `/login` route exposed by the middleware, like so:

```js
// pseudo code
router.get('/login', (req, res) => {
  const config = req.app.config.auth || defaultConfig
  const token = jwt.sign(user, 'secret', {
    exp: config.jwtExpiration
  })
  res.send(token)
})
```

This will resolve many of the issues the plugin is facing right now, which depends basically on the possibility to pass custom configurations.

### Pros

- [x] Backward compatibility
- [x] Extend plugins possibilities
- [x] Enrich middleware use

The third point is about having [this](https://github.com/typicode/json-server#add-middlewares) middleware features to be capable of handling the basic needs otherwise implemented by the [modules](https://github.com/typicode/json-server#module) which requires the author of the plugin to depend on a (per package) version of json-server instead of simply hook up to the user choice version as middleware.

### Cons

Any consequence? I'm open to feedbacks.

---

My english is not very good and I've helped myself with g.translator, so if something is not clear about what I tried to explain, please tell me 😄 