### PR TITLE
Feat: Support for bulk insertion

### DIFF
--- a/__tests__/server/plural-with-custom-foreign-key.js
+++ b/__tests__/server/plural-with-custom-foreign-key.js
@@ -100,7 +100,7 @@ describe('Server with custom foreign key', () => {
         .post('/posts/1/comments')
         .send({ body: 'foo' })
         .expect('Content-Type', /json/)
-        .expect({ id: 4, post_id: '1', body: 'foo' })
+        .expect({ id: 4, post_id: 1, body: 'foo' })
         .expect(201))
   })
 

--- a/__tests__/server/plural.js
+++ b/__tests__/server/plural.js
@@ -554,7 +554,7 @@ describe('Server', () => {
         .post('/posts/1/comments')
         .send({ body: 'foo' })
         .expect('Content-Type', /json/)
-        .expect({ id: 6, postId: '1', body: 'foo' })
+        .expect({ id: 6, postId: 1, body: 'foo' })
         .expect(201))
   })
 

--- a/__tests__/server/plural.js
+++ b/__tests__/server/plural.js
@@ -348,6 +348,13 @@ describe('Server', () => {
         .expect('Content-Type', /json/)
         .expect(db.comments.slice(1))
         .expect(200))
+
+    test.skip('should accept multiple parameters', () =>
+      request(server)
+        .get('/comments?id_ne=1&id_ne=2')
+        .expect('Content-Type', /json/)
+        .expect(db.comments.slice(1))
+        .expect(200))
   })
 
   describe('GET /:resource?attr_like=', () => {
@@ -526,6 +533,32 @@ describe('Server', () => {
       assert.strictEqual(db.posts.length, 3)
     })
 
+    test('should support bulk insertion', async () => {
+      await request(server)
+        .post('/posts')
+        .send([
+          {
+            body: 'foo bar'
+          },
+          {
+            body: 'foo baz'
+          }
+        ])
+        .expect('Content-Type', /json/)
+        .expect([
+          {
+            id: 3,
+            body: 'foo bar'
+          },
+          {
+            id: 4,
+            body: 'foo baz'
+          }
+        ])
+        .expect(201)
+      assert.strictEqual(db.posts.length, 4)
+    })
+
     test('should support x-www-form-urlencoded', async () => {
       await request(server)
         .post('/posts')
@@ -555,6 +588,32 @@ describe('Server', () => {
         .send({ body: 'foo' })
         .expect('Content-Type', /json/)
         .expect({ id: 6, postId: 1, body: 'foo' })
+        .expect(201))
+
+    test('should support bulk insertion', () =>
+      request(server)
+        .post('/posts/1/comments')
+        .send([
+          {
+            body: 'foo'
+          },
+          {
+            body: 'bar'
+          }
+        ])
+        .expect('Content-Type', /json/)
+        .expect([
+          {
+            id: 6,
+            postId: 1,
+            body: 'foo'
+          },
+          {
+            id: 7,
+            postId: 1,
+            body: 'bar'
+          }
+        ])
         .expect(201))
   })
 

--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const express = require('express')
 const pluralize = require('pluralize')
 const delay = require('./delay')
@@ -16,8 +17,16 @@ module.exports = opts => {
 
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post(req, res, next) {
-    const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}${opts.foreignKeySuffix}`] = parseInt(req.params.id)
+    const id = parseInt(req.params.id)
+    const prop = pluralize.singular(req.params.resource) + opts.foreignKeySuffix
+    if (_.isArray(req.body)) {
+      req.body = req.body.map(r => ({
+        ...r,
+        [prop]: id
+      }))
+    } else {
+      req.body[prop] = id
+    }
     req.url = `/${req.params.nested}`
     next()
   }

--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -17,7 +17,7 @@ module.exports = opts => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post(req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}${opts.foreignKeySuffix}`] = req.params.id
+    req.body[`${prop}${opts.foreignKeySuffix}`] = parseInt(req.params.id)
     req.url = `/${req.params.nested}`
     next()
   }

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -281,7 +281,7 @@ module.exports = (db, name, opts) => {
   // PUT /name/:id
   // PATCH /name/:id
   function update(req, res, next) {
-    const id = req.params.id
+    const id = parseInt(req.params.id)
     let resource
 
     if (opts._isFake) {


### PR DESCRIPTION
Added support for bulk insertion when posting array to plural and nested routes.
```
POST /posts 
POST /posts/1/comments
```
When a single object is posted it work as usual, when an array (of objects) is posted it will perform bulk insertion.

Also the **id** field is parsed into number to fix match issues, see #396 