### PR TITLE
Keep parent resource id as int instead of str for nested post

### DIFF
--- a/__tests__/server/plural-with-custom-foreign-key.js
+++ b/__tests__/server/plural-with-custom-foreign-key.js
@@ -100,7 +100,7 @@ describe('Server with custom foreign key', () => {
         .post('/posts/1/comments')
         .send({ body: 'foo' })
         .expect('Content-Type', /json/)
-        .expect({ id: 4, post_id: '1', body: 'foo' })
+        .expect({ id: 4, post_id: 1, body: 'foo' })
         .expect(201))
   })
 

--- a/__tests__/server/plural.js
+++ b/__tests__/server/plural.js
@@ -554,7 +554,7 @@ describe('Server', () => {
         .post('/posts/1/comments')
         .send({ body: 'foo' })
         .expect('Content-Type', /json/)
-        .expect({ id: 6, postId: '1', body: 'foo' })
+        .expect({ id: 6, postId: 1, body: 'foo' })
         .expect(201))
   })
 

--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -17,7 +17,7 @@ module.exports = opts => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post(req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}${opts.foreignKeySuffix}`] = req.params.id
+    req.body[`${prop}${opts.foreignKeySuffix}`] = parseInt(req.params.id, 10)
     req.url = `/${req.params.nested}`
     next()
   }


### PR DESCRIPTION
### Current behaviour:
`POST` on nested resources creates a resource with parent resource id value as string. 

eg: 

```js
POST /posts/1/comments
{
    "body": "some comment"
}
---
{
    "body": "some comment",
    "createdAt": 1555443321417,
    "postId": "1", // <string>
    "id": 1
}
```

`_embed` doesn't pick up resources where corresponding parent resource id is `string`:

```js
GET /posts/1?_embed=comments
---
{
    "id": 1,
    "title": "json-server", 
    "author": "typicode",
    "comments": [] // empty!!!
}
```
---

### Behaviour after the fix:

This PR **casts the parent resource id to `int` on nested resource `POST` request body.** 

```js
POST /posts/1/comments
{
    "body": "some comment"
}
---
{
    "body": "some comment",
    "createdAt": 1555443321417,
    "postId": 1, // <int>
    "id": 1
}
```

Which in turn fixes `_embed`'s response:

```js
GET /posts/1?_embed=comments
---
{
    "id": 1,
    "title": "json-server", 
    "author": "typicode",
    "comments": [ // not empty
        {
            "body": "some comment",
            "createdAt": 1555443321417,
            "postId": 1,
            "id": 1
        }
    ]
}
```