### PR TITLE
Added route for exiting process, closes #834

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ See also:
 * :dog: [husky - Git hooks made easy](https://github.com/typicode/husky)
 * :hotel: [hotel - developer tool with local .localhost domain and https out of the box](https://github.com/typicode/hotel)
 
-<a href="https://www.patreon.com/typicode">
-  <img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" width="160">
-</a>
-
 <h2 align="center">Sponsors</h2>
 
 <h3 align="center">Gold</h3>

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See also:
   * [Relationships](#relationships)
   * [Database](#database)
   * [Homepage](#homepage)
+  * [Exit](#exit)
 - [Extras](#extras)
   * [Static file server](#static-file-server)
   * [Alternative port](#alternative-port)
@@ -263,6 +264,15 @@ Returns default index file or serves `./public` directory
 
 ```
 GET /
+```
+
+### Exit
+
+Terminates process running json-server, returns a 200 before and after termination 
+the success code (0).
+
+```
+GET /__exit
 ```
 
 ## Extras

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -47,6 +47,14 @@ module.exports = (db, opts = { foreignKeySuffix: 'Id', _isFake: false }) => {
     res.jsonp(db.getState())
   })
 
+  // GET /__exit
+  router.get('/__exit', (req, res) => {
+    res.sendStatus(200)
+    res.on('finish', () => {
+      process.exit()
+    })
+  })
+
   // Handle /:parent/:parentId/:resource
   router.use(nested(opts))
 


### PR DESCRIPTION
Added the route (/__exit) to terminate the process running json-server, like propsed in the Issue #834.
Before termination it will be a 200 sent and after termination a success code (0) returned. 
Also updated README.md to mention this route.