### PR TITLE
support POST PUT PATCH DELETE multiple field

### DIFF
--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -17,7 +17,13 @@ module.exports = opts => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post(req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}${opts.foreignKeySuffix}`] = req.params.id
+    if (Array.isArray(req.body)) {
+      for (let i = 0; i < req.body.length; i++) {
+        req.body[i][`${prop}${opts.foreignKeySuffix}`] = req.params.id
+      }
+    } else {
+      req.body[`${prop}${opts.foreignKeySuffix}`] = req.params.id
+    }
     req.url = `/${req.params.nested}`
     next()
   }


### PR DESCRIPTION
Added support for POST PUT PATCH DELETE of multiple field.

When an object is given, it works as usual.
When an array is given, POST performs bulk creation, PUT PATCH DELETE ignore the /:id/ and take the id property of objects in the array