### PR TITLE
Fixing AppVeyor build by bumping Node version from 7 to 8, closes #979

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "7"
+  nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
AppVeyor was still using Node 7 and not 8, like required from May 20th with Commit [#ddd151](https://github.com/typicode/json-server/commit/ddd151787e74be264f2018e42c008e45c56a9cc2#diff-b9cfc7f2cdf78a7f4b91a753d10865a2). That was the reason why tests failed with AppVeyor.