### PR TITLE
Enabled to see response status code.

### DIFF
--- a/src/front/index.js
+++ b/src/front/index.js
@@ -71,10 +71,17 @@ function CustomRoutesBlock({ customRoutes }) {
 
 window
   .fetch('__rules')
+  .then(response => {
+    if (!response.ok) {
+      throw Error(response.statusText)
+    } else {
+      return response.ok
+    }
+  })
   .then(response => response.json())
-  .then(
-    customRoutes =>
-      (document.getElementById('custom-routes').innerHTML = CustomRoutesBlock({
-        customRoutes
-      }))
-  )
+  .then(customRoutes => {
+    document.getElementById('custom-routes').innerHTML = CustomRoutesBlock({
+      customRoutes
+    })
+  })
+  .catch(error => console.log(error))


### PR DESCRIPTION
Related #981

Since the element which has id=custom-routes is modified by JS, so cli, server tests can’t confirm if this fixed or not.
I add the sample test script to confirm the changeset by using Cypress.

```JavaScript
import { createVerify } from "crypto";

describe('JSON Server test', () => {
    it('Shows Top', () => {
      cy.visit('http://localhost:3000/')

      cy.title().should('include', 'JSON Server')
      cy.get('div#custom-routes').should('not.have.text', 'undefined')
    })
  })
```


