### PR TITLE
Allow CLI to use any kind of require-able module

### DIFF
--- a/src/cli/utils/is.js
+++ b/src/cli/utils/is.js
@@ -1,6 +1,6 @@
 module.exports = {
   FILE,
-  JS,
+  Module,
   URL
 }
 
@@ -8,8 +8,13 @@ function FILE(s) {
   return !URL(s) && /\.json$/.test(s)
 }
 
-function JS(s) {
-  return !URL(s) && /\.js$/.test(s)
+function Module(s) {
+  try {
+    require(s)
+    return true
+  } catch (error) {
+    return false
+  }
 }
 
 function URL(s) {

--- a/src/cli/utils/load.js
+++ b/src/cli/utils/load.js
@@ -35,7 +35,7 @@ module.exports = function(source) {
         if (err) return reject(err)
         resolve(low(new Memory()).setState(response.body))
       })
-    } else if (is.JS(source)) {
+    } else if (is.Module(source)) {
       // Clear cache
       const filename = path.resolve(source)
       delete require.cache[filename]


### PR DESCRIPTION
This would allow the CLI to load the DB from any compile-to-JS language directly, removing the need to do it programatically as long as the necessary compiler is loaded.
The `NODE_OPTIONS` env var allows us to pass opts directly to the nodejs binary when running CLI applications. This way, we can actually allow the CLI to directly load TypeScript files, or CoffeeScript files, or Babel, or whatever else.
I already tried this modification and it works nicely with TypeScript (using ts-node) by doing:

```bash
NODE_OPTIONS="--require ts-node/register" json-server db.ts
```

And having `db.ts` with:

```typescript
import * as casual from 'casual'
import { Item } from './src/interfaces'

function generateItem(): Item {
  return {
    docType: 'item',
    uid: casual.uuid,
    owner: casual.first_name.toLowerCase(),
    name: casual.name,
    graphics: {
      images: [
        `https://loremflickr.com/1280/720`,
        `https://loremflickr.com/640/360`
      ]
    }
  }
}

export = () => ({
  items: new Array(100).map(generateItem)
})
```