### PR TITLE
Fix for multiple _ne operators

### DIFF
--- a/__tests__/server/plural.js
+++ b/__tests__/server/plural.js
@@ -348,6 +348,13 @@ describe('Server', () => {
         .expect('Content-Type', /json/)
         .expect(db.comments.slice(1))
         .expect(200))
+
+    test('should accept multiple parameters', () =>
+      request(server)
+        .get('/comments?id_ne=1&id_ne=2')
+        .expect('Content-Type', /json/)
+        .expect(db.comments.slice(2))
+        .expect(200))
   })
 
   describe('GET /:resource?attr_like=', () => {
@@ -356,6 +363,12 @@ describe('Server', () => {
         .get('/tags?body_like=photo')
         .expect('Content-Type', /json/)
         .expect([db.tags[1], db.tags[2]])
+        .expect(200))
+    test('should accept multiple parameters', () =>
+      request(server)
+        .get('/tags?body_like=photo&body_like=tech')
+        .expect('Content-Type', /json/)
+        .expect(db.tags)
         .expect(200))
   })
 

--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -116,13 +116,14 @@ module.exports = (db, name, opts) => {
         // Always use an array, in case req.query is an array
         const arr = [].concat(req.query[key])
 
+        const isDifferent = /_ne$/.test(key)
+        const isRange = /_lte$/.test(key) || /_gte$/.test(key)
+        const isLike = /_like$/.test(key)
+        const path = key.replace(/(_lte|_gte|_ne|_like)$/, '')
+
         chain = chain.filter(element => {
           return arr
             .map(function(value) {
-              const isDifferent = /_ne$/.test(key)
-              const isRange = /_lte$/.test(key) || /_gte$/.test(key)
-              const isLike = /_like$/.test(key)
-              const path = key.replace(/(_lte|_gte|_ne|_like)$/, '')
               // get item value based on path
               // i.e post.title -> 'foo'
               const elementValue = _.get(element, path)
@@ -146,7 +147,7 @@ module.exports = (db, name, opts) => {
                 return value === elementValue.toString()
               }
             })
-            .reduce((a, b) => a || b)
+            .reduce((a, b) => (isDifferent ? a && b : a || b))
         })
       }
     })


### PR DESCRIPTION
When filtering with multiple _ne it should use logical AND instead of OR to verify that all checks succeed, close #929