### PR TITLE
Allow the use of next in user defined render

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -74,13 +74,13 @@ module.exports = (db, opts = { foreignKeySuffix: 'Id', _isFake: false }) => {
     throw new Error(msg)
   }).value()
 
-  router.use((req, res) => {
+  router.use((req, res, next) => {
     if (!res.locals.data) {
       res.status(404)
       res.locals.data = {}
     }
 
-    router.render(req, res)
+    router.render(req, res, next)
   })
 
   router.use((err, req, res, next) => {


### PR DESCRIPTION
In some cases, you may want to pass another middleware to the render function, allowing the developer to render at a later time.