### PR TITLE
Clarify that `id` is provided on POST requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Also when doing requests, it's good to know that:
 - If you make POST, PUT, PATCH or DELETE requests, changes will be automatically and safely saved to `db.json` using [lowdb](https://github.com/typicode/lowdb).
 - Your request body JSON should be object enclosed, just like the GET output. (for example `{"name": "Foobar"}`)
 - Id values are not mutable. Any `id` value in the body of your PUT or PATCH request will be ignored. Only a value set in a POST request will be respected, but only if not already taken.
+- When you make a POST request without an `id`, one will be provided for the record in a monotonically increasing fashion.
 - A POST, PUT or PATCH request should include a `Content-Type: application/json` header to use the JSON in the request body. Otherwise it will result in a 200 OK but without changes being made to the data.
 
 ## Routes


### PR DESCRIPTION
This PR clarifies in the opening docs that a `POST` request will automatically provide an `id` when one is not specified on the request. I love the feature and had to do some testing to verify it actually happens. One would expect this to happen, but it's so wonderful in its magic that it's worth emphasizing that yes, indeed, it happens.