### PR TITLE
Enable using single number in response body

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -52,7 +52,7 @@ module.exports = (db, opts = { foreignKeySuffix: 'Id', _isFake: false }) => {
 
   // Create routes
   db.forEach((value, key) => {
-    if (_.isPlainObject(value)) {
+    if (_.isPlainObject(value) || typeof value === 'number') {
       router.use(`/${key}`, singular(db, key, opts))
       return
     }
@@ -69,13 +69,13 @@ module.exports = (db, opts = { foreignKeySuffix: 'Id', _isFake: false }) => {
 
     const msg =
       `Type of "${key}" (${typeof value}) ${sourceMessage} is not supported. ` +
-      `Use objects or arrays of objects.`
+      `Use number, objects or arrays of objects.`
 
     throw new Error(msg)
   }).value()
 
   router.use((req, res) => {
-    if (!res.locals.data) {
+    if (res.locals.data === undefined) {
       res.status(404)
       res.locals.data = {}
     }


### PR DESCRIPTION
Based on discussion [here](https://github.com/typicode/json-server/issues/832), I think it might be useful to allow mocked API to return a single number as response. So I created the following pull request. Please help take a look if this is appropriate. Thank you for the awesome project!!