### PR TITLE
add jitter option

### DIFF
--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -188,6 +188,25 @@ describe('cli', () => {
     })
   })
 
+  describe('db.json -d 500 -j 500', () => {
+    beforeEach(done => {
+      child = cli([dbFile, '-d', 500, '-j', 500])
+      serverReady(PORT, done)
+    })
+
+    test('should jitter the response', done => {
+      const start = new Date()
+      request.get('/posts').expect(200, function(err) {
+        const end = new Date()
+        done(
+          end - start > 500 && end - start < 1000
+            ? err
+            : new Error("Request wasn't jittered")
+        )
+      })
+    })
+  })
+
   describe('db.json -s ../../__fixtures__/public -S /some/path/snapshots', () => {
     const snapshotsDir = path.join(osTmpdir(), 'snapshots')
     const publicDir = '../../__fixtures__/public'

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -58,6 +58,10 @@ module.exports = function() {
         alias: 'd',
         description: 'Add delay to responses (ms)'
       },
+      jitter: {
+        alias: 'j',
+        description: 'Add random delay to each response (ms)'
+      },
       id: {
         alias: 'i',
         description: 'Set database id property (e.g. _id)',

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -8,6 +8,7 @@ const pause = require('connect-pause')
 const is = require('./utils/is')
 const load = require('./utils/load')
 const jsonServer = require('../server')
+const jitter = require('./utils/jitter')
 
 function prettyPrint(argv, object, rules) {
   const root = `http://${argv.host}:${argv.port}`
@@ -68,6 +69,10 @@ function createApp(db, routes, middlewares, argv) {
 
   if (argv.delay) {
     app.use(pause(argv.delay))
+  }
+
+  if (argv.jitter) {
+    app.use(jitter(argv.jitter))
   }
 
   router.db._.id = argv.id

--- a/src/cli/utils/jitter.js
+++ b/src/cli/utils/jitter.js
@@ -1,0 +1,4 @@
+module.exports = delay => (req, res, next) => {
+  const jitter = Math.floor(Math.random() * (delay + 1)) // [0, delay]
+  setTimeout(next, jitter)
+}


### PR DESCRIPTION
This resolve issue https://github.com/typicode/json-server/issues/488

The jitter option adds a random delay to each response. It can be used with or without the delay option.