### PR TITLE
Introduce --generate flag for creating missing source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Options:
   --foreignKeySuffix, --fks  Set foreign key suffix, (e.g. _id as in post_id)
                                                                  [default: "Id"]
   --quiet, -q        Suppress log messages from output                 [boolean]
+  --generate, -g     Generate source file if missing                   [boolean]
   --help, -h         Show help                                         [boolean]
   --version, -v      Show version number                               [boolean]
 

--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -281,15 +281,28 @@ describe('cli', () => {
     })
   })
 
-  describe('non existent db.json', () => {
+  describe('non existent db.json with generate flag', () => {
     beforeEach(done => {
       fs.unlinkSync(dbFile)
-      child = cli([dbFile])
+      child = cli([dbFile, '--generate'])
       serverReady(PORT, done)
     })
 
     test("should create JSON file if it doesn't exist", done => {
       request.get('/posts').expect(200, done)
+    })
+  })
+
+  describe('non existent db.json without generate flag', () => {
+    test('should exit with an error', done => {
+      fs.unlinkSync(dbFile)
+      child = cli([dbFile])
+      child.on('exit', code => {
+        if (code === 1) {
+          return done()
+        }
+        return done(new Error('should exit with error code'))
+      })
     })
   })
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -76,6 +76,10 @@ module.exports = function() {
         alias: 'c',
         description: 'Path to config file',
         default: 'json-server.json'
+      },
+      generate: {
+        alias: 'g',
+        description: 'Generate source file if missing'
       }
     })
     .boolean('watch')
@@ -83,6 +87,7 @@ module.exports = function() {
     .boolean('quiet')
     .boolean('no-cors')
     .boolean('no-gzip')
+    .boolean('generate')
     .help('help')
     .alias('help', 'h')
     .version(pkg.version)

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -79,6 +79,7 @@ function createApp(db, routes, middlewares, argv) {
 
 module.exports = function(argv) {
   const source = argv._[0]
+  const generateFileIfMissing = argv.generate
   let app
   let server
 
@@ -103,7 +104,7 @@ module.exports = function(argv) {
     server = undefined
 
     // create db and load object, JSON file, JS or HTTP database
-    return load(source).then(db => {
+    return load(source, generateFileIfMissing).then(db => {
       // Load additional routes
       let routes
       if (argv.routes) {

--- a/src/cli/utils/load.js
+++ b/src/cli/utils/load.js
@@ -13,14 +13,21 @@ const example = {
   profile: { name: 'typicode' }
 }
 
-module.exports = function(source) {
+module.exports = function(source, generateFileIfMissing) {
   return new Promise((resolve, reject) => {
     if (is.FILE(source)) {
       if (!fs.existsSync(source)) {
-        console.log(chalk.yellow(`  Oops, ${source} doesn't seem to exist`))
-        console.log(chalk.yellow(`  Creating ${source} with some default data`))
-        console.log()
-        fs.writeFileSync(source, JSON.stringify(example, null, 2))
+        const err = `  Oops, ${source} doesn't seem to exist`
+        if (generateFileIfMissing) {
+          console.log(chalk.yellow(err))
+          console.log(
+            chalk.yellow(`  Creating ${source} with some default data`)
+          )
+          console.log()
+          fs.writeFileSync(source, JSON.stringify(example, null, 2))
+        } else {
+          return reject(chalk.red(err))
+        }
       }
 
       resolve(low(new FileAsync(source)))


### PR DESCRIPTION
Answering [this Stack Overflow question](https://stackoverflow.com/q/63923087/3001761) I found that by default, if a source file name is provided but no such file is found, an example file is generated. This is mentioned in the output:
```
  Loading test.json
  Oops, test.json doesn't seem to exist
  Creating test.json with some default data
```
but is easy to miss. As the file is now created, there's no information that this happened on subsequent starts. This leaves an unwary user confused as to why their edits to the (wrong) JSON file don't seem to have any impact.

Therefore I've introduced a `-g`/`--generate` flag. Without this CLI flag, if the file is missing, the server bails out. If you supply the flag, the old behaviour is restored.

This is strictly a **breaking change**; anyone who was relying on this to create the file will now have to explicitly supply the flag. However it seems unlikely too many people are purposefully relying on that feature, as the default canned data isn't terribly useful.

In terms of the specific implementation, I considered:

- Defaulting to generating the missing source and using a flag to disable it, but doesn't solve the problem for the unwary user.
- Passing all of `argv` to `load`, but adding the extra `generateFileIfMissing` parameter seemed less impactful in terms of encapsulation. I'm open to other suggestions on the name...
- Explicitly warning if the flag was passed for a non-file source, but that didn't seem very high value.
- Adding a suggestion (_"To generate a file, supply the --generate flag"_ or something) to the error message to ease the transition, but there didn't seem like a particularly neat way to do this.