### PR TITLE
fix: throw error if inner resource not singular

### DIFF
--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -31,6 +31,13 @@ module.exports = (db, name, opts) => {
   function expand(resource, e) {
     e &&
       [].concat(e).forEach((innerResource) => {
+        if (pluralize.isPlural(innerResource)) {
+          const correctInnerResource = pluralize.singular(innerResource)
+          throw new Error(
+            `${innerResource} - inner resource must be singular (_expand=${correctInnerResource})`
+          )
+        }
+
         const plural = pluralize(innerResource)
         if (db.get(plural).value()) {
           const prop = `${innerResource}${opts.foreignKeySuffix}`


### PR DESCRIPTION
Route: http://localhost:3000/comments?_expand=posts

Before:
```
TypeError: Cannot read property 'toString' of undefined at ...
```

After:
```
Error: posts - inner resource must be singular (_expand=post) at ...
```