### PR TITLE
Allow middleware after router.

### DIFF
--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -83,8 +83,8 @@ module.exports = (db, opts) => {
     }
 
     router.render(req, res)
-	
-	next()
+
+    next()
   })
 
   router.use((err, req, res, next) => {

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -76,13 +76,15 @@ module.exports = (db, opts) => {
     throw new Error(msg)
   }).value()
 
-  router.use((req, res) => {
+  router.use((req, res, next) => {
     if (!res.locals.data) {
       res.status(404)
       res.locals.data = {}
     }
 
     router.render(req, res)
+	
+	next()
   })
 
   router.use((err, req, res, next) => {


### PR DESCRIPTION
To allow json_server to superseed a proxy-server.
I.e. allow calls to the proxy-server if no routes
matches the json_server. 
Which means we need to handle the 404
response after json_server::router middleware.