### PR TITLE
Implemented exclude filters for return fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,22 @@ GET  /posts/1/comments
 POST /posts/1/comments
 ```
 
+### Exclude returns fields
+
+To exclude fields from returns resources, add `_exclude`
+
+```http request
+GET /posts?_exclude=createdAt,author.email,comments
+```
+
+To exclude all fields from returns resources, except a few, add `_exclude`
+
+```http request
+GET /posts?_only=title,content,author.name
+```
+
+> :warning: `_only` param have priority on `_exclude`. If you pass `_only=...,_exlcude=...` `_exclude` will be ignored.
+
 ### Database
 
 ```


### PR DESCRIPTION
My wife was doing a test task and she needed to get only certain fields for easier filtering on the client.

I looked at the Readme and the source code but couldn't find such a possibility. After a bit of research I realized that it was pretty easy to do it using lodash and did it.

PS: I'm a Python backend developer and this is my first time writing in Node.js, so don't judge strictly :)