### PR TITLE
When there aren't any custom routes and it'll show "no custom routes" messages instead of undefined  

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -43,26 +43,35 @@ window
       (document.getElementById('resources').innerHTML = ResourcesBlock({ db }))
   )
 
-function CustomRoutesBlock({ customRoutes }) {
-  const rules = Object.keys(customRoutes)
-  if (rules.length) {
-    return `
-      <div>
-        <h1>Custom Routes</h1>
-        <table>
-          ${rules
-            .map(
-              (rule) =>
-                `<tr>
+function CustomRoutesList(rules, customRoutes) {
+  return rules
+    .map(
+      (rule) => `<tr>
               <td>${rule}</td>
               <td><code>⇢</code> ${customRoutes[rule]}</td>
             </tr>`
-            )
-            .join('')}
-        </table>
-      </div>
-    `
-  }
+    )
+    .join('')
+}
+
+function NoCustomRoutes() {
+  return `<p>No custom routes found</p>`
+}
+
+function CustomRoutesBlock({ customRoutes }) {
+  const rules = Object.keys(customRoutes)
+  return `
+    <div>
+      <h1>Custom Routes</h1>
+      <table>
+        ${
+          rules.length
+            ? CustomRoutesList(rules, customRoutes)
+            : NoCustomRoutes()
+        }
+      </table>
+    </div>
+  `
 }
 
 window


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/41575415/139300440-62822754-4c29-49d3-a848-4127665822e5.png)

### Description
When there aren't any custom routes with `JsonServer.defaults()` and `CustomRoutesBlock` returns "undefined" implicitly 
And I changed to the default message like NoResources.

### After
![image](https://user-images.githubusercontent.com/41575415/139298785-6889691a-ca8f-4492-b864-c162be2fbe93.png)
