### PR TITLE
ADD error message when 'db.json' has record with no 'id' property

### DIFF
--- a/src/server/mixins.js
+++ b/src/server/mixins.js
@@ -45,10 +45,19 @@ function createId(coll) {
   if (_.isEmpty(coll)) {
     return 1
   } else {
-    let id = _(coll).maxBy(idProperty)[idProperty]
-
-    // Increment integer id or generate string id
-    return _.isFinite(id) ? ++id : nanoid(7)
+    try {
+      let id = _(coll).maxBy(idProperty)[idProperty]
+      // Increment integer id or generate string id
+      return _.isFinite(id) ? ++id : nanoid(7)
+    } catch (error) {
+      console.log(error)
+      console.log(`
+        No ID found on db record
+          This likely due to a pre-populated record in 'db.json' not having
+          an 'id' property for the record. See:
+          https://github.com/typicode/json-server/issues/798
+          `)
+    }
   }
 }
 


### PR DESCRIPTION
This is a common error when initially setting up json-server. This provides an error for how to fix the problem.

I setup json-server once or twice a year for a new project. I always get bitten by the issue that I have not defined an 'id' property on a route in db.json. This pull requests provides a helpful error message.

Issue https://github.com/typicode/json-server/issues/798 shows that other people are have the same problem.