### PR TITLE
chore: binding host to ::1 (0.0.0.0) when no host parameter is provided

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -125,7 +125,10 @@ module.exports = function (argv) {
 
       // Create app and server
       app = createApp(db, routes, middlewares, argv)
-      server = app.listen(argv.port, argv.host)
+      server =
+        argv.host === 'localhost'
+          ? app.listen(argv.port)
+          : app.listen(argv.port, argv.host)
 
       // Enhance with a destroy function
       enableDestroy(server)


### PR DESCRIPTION
When trying to run from a docker container, binding the listener to 'localhost' doesn't allow it to be reachable from outside the container. By removing the host from app.listen method, it makes express to bind the listener to ::1 (0.0.0.0), accepting requests for any hostname. If a value different than the default is provided, it binds it accordingly.