### PR TITLE
ignore $schema definition

### DIFF
--- a/__tests__/server/schema-ignore.js
+++ b/__tests__/server/schema-ignore.js
@@ -1,7 +1,7 @@
 const request = require('supertest')
 const jsonServer = require('../../src/server')
 
-describe('Schema-ignore', () => {
+describe('$schema-ignore', () => {
   let server
   let router
   let db
@@ -22,30 +22,7 @@ describe('Schema-ignore', () => {
     server.use(router)
   })
 
-  describe('GET /:resource', () => {
-    test('should respond with corresponding resource', () =>
-      request(server).get('/user').expect(200, db.user))
-  })
-
-  describe('POST /:resource', () => {
-    test('should create resource', () => {
-      const user = { name: 'bar' }
-      return request(server).post('/user').send(user).expect(201, user)
-    })
-  })
-
-  describe('PUT /:resource', () => {
-    test('should update resource', () => {
-      const user = { name: 'bar' }
-      return request(server).put('/user').send(user).expect(200, user)
-    })
-  })
-
-  describe('PATCH /:resource', () => {
-    test('should update resource', () =>
-      request(server)
-        .patch('/user')
-        .send({ name: 'bar' })
-        .expect(200, { name: 'bar', email: 'foo@example.com' }))
+  test('doesnt error with $schema node', () => {
+    return request(server).get('/user').expect(200, db.user)
   })
 })

--- a/__tests__/server/schema-ignore.js
+++ b/__tests__/server/schema-ignore.js
@@ -1,0 +1,51 @@
+const request = require('supertest')
+const jsonServer = require('../../src/server')
+
+describe('Schema-ignore', () => {
+  let server
+  let router
+  let db
+
+  beforeEach(() => {
+    db = {
+      $schema: 'http://some.schema.somewhere/',
+    }
+
+    db.user = {
+      name: 'foo',
+      email: 'foo@example.com',
+    }
+
+    server = jsonServer.create()
+    router = jsonServer.router(db)
+    server.use(jsonServer.defaults())
+    server.use(router)
+  })
+
+  describe('GET /:resource', () => {
+    test('should respond with corresponding resource', () =>
+      request(server).get('/user').expect(200, db.user))
+  })
+
+  describe('POST /:resource', () => {
+    test('should create resource', () => {
+      const user = { name: 'bar' }
+      return request(server).post('/user').send(user).expect(201, user)
+    })
+  })
+
+  describe('PUT /:resource', () => {
+    test('should update resource', () => {
+      const user = { name: 'bar' }
+      return request(server).put('/user').send(user).expect(200, user)
+    })
+  })
+
+  describe('PATCH /:resource', () => {
+    test('should update resource', () =>
+      request(server)
+        .patch('/user')
+        .send({ name: 'bar' })
+        .expect(200, { name: 'bar', email: 'foo@example.com' }))
+  })
+})

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -15,6 +15,9 @@ function prettyPrint(argv, object, rules) {
   console.log()
   console.log(chalk.bold('  Resources'))
   for (const prop in object) {
+    // skip printing $schema nodes
+    if (prop === '$schema') continue
+
     console.log(`  ${root}/${prop}`)
   }
 

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -54,6 +54,11 @@ module.exports = (db, opts) => {
 
   // Create routes
   db.forEach((value, key) => {
+    if (key === '$schema') {
+      // ignore $schema
+      return
+    }
+
     if (_.isPlainObject(value)) {
       router.use(`/${key}`, singular(db, key, opts))
       return


### PR DESCRIPTION
This pull request addresses #1323 for ignoring $schema node

Lots of editors, VSCode, can validate your json based on the $schema node declaration.  This initial pull request (more to follow) simply ignores the $schema node.  

Second phase is to actually add support for $schema declaration in the json.

