### PR TITLE
Add custom router for custom respond

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ __Please help me build OSS__ 👉 [GitHub Sponsors](https://github.com/sponsors/
     + [Simple example](#simple-example)
     + [Custom routes example](#custom-routes-example)
     + [Access control example](#access-control-example)
-    + [Custom output example](#custom-output-example)
+    + [Custom router example](#custom-router-example)
     + [Rewriter example](#rewriter-example)
     + [Mounting JSON Server on another endpoint example](#mounting-json-server-on-another-endpoint-example)
     + [API](#api)
@@ -537,29 +537,26 @@ server.listen(3000, () => {
   console.log('JSON Server is running')
 })
 ```
-#### Custom output example
 
-To modify responses, overwrite `router.render` method:
+#### Custom router example
 
-```javascript
-// In this example, returned resources will be wrapped in a body property
-router.render = (req, res) => {
-  res.jsonp({
-    body: res.locals.data
-  })
-}
-```
-
-You can set your own status code for the response:
-
+You can modify responses using Express Router
 
 ```javascript
-// In this example we simulate a server side error response
-router.render = (req, res) => {
-  res.status(500).jsonp({
-    error: "error message here"
+server = jsonServer.create()
+
+customRouter = express.Router()
+router = jsonServer.router(db, { customRouter })
+
+server.use(jsonServer.defaults())
+server.use(router)
+
+customRouter.post('/posts', (req, res) => {
+  res.jsonp({ 
+    ...res.locals.data, 
+    customData: 'hello' 
   })
-}
+})
 ```
 
 #### Rewriter example

--- a/__tests__/server/custom-router.js
+++ b/__tests__/server/custom-router.js
@@ -1,0 +1,70 @@
+const assert = require('assert')
+const { Router } = require('express')
+const request = require('supertest')
+const jsonServer = require('../../src/server')
+
+describe('Server', () => {
+  let server
+  let router
+  let db
+  let customRouter
+  let customRespond
+
+  beforeEach(() => {
+    db = {}
+
+    db.posts = [
+      { id: 1, body: 'foo' },
+      { id: 2, body: 'bar' },
+    ]
+
+    db.tags = [
+      { id: 1, body: 'Technology' },
+      { id: 2, body: 'Photography' },
+      { id: 3, body: 'photo' },
+    ]
+
+    customRespond = { data: 'Custom respond', message: 'Hello' }
+
+    server = jsonServer.create()
+    customRouter = Router()
+    router = jsonServer.router(db, { customRouter })
+    server.use(jsonServer.defaults())
+    server.use(router)
+  })
+
+  describe('GET /:resource', () => {
+    test('should respond with json and custom resources', () => {
+      const route = '/posts'
+      customRouter.get(route, (req, res) => {
+        res.jsonp(customRespond)
+      })
+
+      return request(server)
+        .get(route)
+        .set('Origin', 'http://example.com')
+        .expect('Content-Type', /json/)
+        .expect('Access-Control-Allow-Credentials', 'true')
+        .expect('Access-Control-Allow-Origin', 'http://example.com')
+        .expect(200, customRespond)
+    })
+  })
+
+  describe('POST /:resource', () => {
+    test('should respond with custom json, create a resource and increment id', async () => {
+      const route = '/posts'
+      customRouter.post(route, (req, res) => {
+        res.jsonp(customRespond)
+      })
+
+      await request(server)
+        .post('/posts')
+        .send({ body: 'foo', booleanValue: true, integerValue: 1 })
+        .expect('Access-Control-Expose-Headers', 'Location')
+        .expect('Location', /posts\/3$/)
+        .expect('Content-Type', /json/)
+        .expect(201, customRespond)
+      assert.strictEqual(db.posts.length, 3)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "json-server",
       "version": "0.17.0",
       "license": "MIT",
       "dependencies": {

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -13,7 +13,10 @@ const singular = require('./singular')
 const mixins = require('../mixins')
 
 module.exports = (db, opts) => {
-  opts = Object.assign({ foreignKeySuffix: 'Id', _isFake: false }, opts)
+  opts = Object.assign(
+    { foreignKeySuffix: 'Id', customRouter: undefined, _isFake: false },
+    opts
+  )
 
   if (typeof db === 'string') {
     db = low(new FileSync(db))
@@ -76,14 +79,16 @@ module.exports = (db, opts) => {
     throw new Error(msg)
   }).value()
 
-  router.use((req, res) => {
+  router.use((req, res, next) => {
     if (!res.locals.data) {
       res.status(404)
       res.locals.data = {}
     }
-
-    router.render(req, res)
+    // Keep router.render for compatability
+    opts.customRouter ? next() : router.render(req, res)
   })
+
+  if (opts.customRouter) router.use(opts.customRouter)
 
   router.use((err, req, res, next) => {
     console.error(err.stack)


### PR DESCRIPTION
I find that overriding `router.render` is cumbersome, so I changed it to using express router, this will keep the lowdb operations while allowing custom responses. I don't know if anyone has tried this before.

Usage: 

```javascript
server = jsonServer.create()
customRouter = express.Router()
router = jsonServer.router(db, { customRouter })
server.use(jsonServer.defaults())
server.use(router)

customRouter.post('/posts', (req, res) => {
  res.jsonp({ customData: 'hello' })
})
```

Related issues:
- typicode/json-server/issues/717
- typicode/json-server/issues/1002