### PR TITLE
Update Faker link to use Faker JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ module.exports = () => {
 $ json-server index.js
 ```
 
-__Tip__ use modules like [Faker](https://github.com/Marak/faker.js), [Casual](https://github.com/boo1ean/casual), [Chance](https://github.com/victorquinn/chancejs) or [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker).
+__Tip__ use modules like [Faker](https://github.com/faker-js/faker), [Casual](https://github.com/boo1ean/casual), [Chance](https://github.com/victorquinn/chancejs) or [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker).
 
 ### HTTPS
 


### PR DESCRIPTION
Maintainer of faker pulled the repo, Faker JS is a fork of the original project.