### PR TITLE
Add some useful features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.log
+__tests__/**/db-*.json
 node_modules
 tmp
 lib

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ lib
 .DS_Store
 .idea
 db.json
+
+.history
+*.tgz

--- a/__tests__/arg.js.run
+++ b/__tests__/arg.js.run
@@ -1,0 +1,15 @@
+const cp = require('child_process')
+test({ _noDataNext: true })
+test({ _noDbRoute: true })
+
+function test(obj) {
+  const arg = Object.entries(obj).reduce((acc, [key, val]) => {
+    return `${acc} ${key}=${val}`
+  }, ``)
+  cp.execSync(
+    `npm run build && npx cross-env NODE_ENV=test arg="${arg}" jest && npm run lint`,
+    {
+      stdio: 'inherit',
+    }
+  )
+}

--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -99,7 +99,7 @@ describe('cli', () => {
     })
   })
 
-  describe.skip('remote db', () => {
+  describe('remote db', () => {
     beforeEach((done) => {
       child = cli(['https://jsonplaceholder.typicode.com/db'])
       serverReady(PORT, done)

--- a/__tests__/cli/index.js
+++ b/__tests__/cli/index.js
@@ -99,7 +99,7 @@ describe('cli', () => {
     })
   })
 
-  describe('remote db', () => {
+  describe.skip('remote db', () => {
     beforeEach((done) => {
       child = cli(['https://jsonplaceholder.typicode.com/db'])
       serverReady(PORT, done)

--- a/__tests__/server/plural.js
+++ b/__tests__/server/plural.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 const _ = require('lodash')
 const request = require('supertest')
 const jsonServer = require('../../src/server')
+const { parseArgv } = require('../../src/server/utils')
+const cliArg = parseArgv(process.env.arg)
 
 describe('Server', () => {
   let server
@@ -87,7 +89,7 @@ describe('Server', () => {
     ]
 
     server = jsonServer.create()
-    router = jsonServer.router(db)
+    router = jsonServer.router(db, cliArg)
     server.use(jsonServer.defaults())
     server.use(jsonServer.rewriter(rewriterRules))
     server.use(router)
@@ -95,7 +97,10 @@ describe('Server', () => {
 
   describe('GET /db', () => {
     test('should respond with json and full database', () =>
-      request(server).get('/db').expect('Content-Type', /json/).expect(200, db))
+      request(server)
+        .get('/db')
+        .expect('Content-Type', /json/)
+        .expect(...(cliArg._noDbRoute ? [404, {}] : [200, db])))
   })
 
   describe('GET /:resource', () => {
@@ -370,7 +375,7 @@ describe('Server', () => {
     test('should respond with 404 if resource is not found', () =>
       request(server)
         .get('/posts/9001')
-        .expect('Content-Type', /json/)
+        .expect('Content-Type', cliArg._noDataNext ? /html/ : /json/)
         .expect(404, {}))
   })
 
@@ -567,7 +572,7 @@ describe('Server', () => {
       request(server)
         .put('/posts/9001')
         .send({ id: 1, body: 'bar' })
-        .expect('Content-Type', /json/)
+        .expect('Content-Type', cliArg._noDataNext ? /html/ : /json/)
         .expect(404, {}))
   })
 
@@ -603,7 +608,7 @@ describe('Server', () => {
       request(server)
         .patch('/posts/9001')
         .send({ body: 'bar' })
-        .expect('Content-Type', /json/)
+        .expect('Content-Type', cliArg._noDataNext ? /html/ : /json/)
         .expect(404, {}))
   })
 
@@ -631,7 +636,7 @@ describe('Server', () => {
     test('should respond with 404 if resource is not found', () =>
       request(server)
         .del('/posts/9001')
-        .expect('Content-Type', /json/)
+        .expect('Content-Type', cliArg._noDataNext ? /html/ : /json/)
         .expect(404, {}))
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@wll8/json-server",
+  "name": "json-server",
   "version": "0.17.2-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@wll8/json-server",
+      "name": "json-server",
       "version": "0.17.2-alpha.5",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "test": "npm run build && cross-env NODE_ENV=test jest && npm run lint",
+    "test": "npm run build && cross-env NODE_ENV=test jest && node __tests__/arg.js.run && npm run lint",
     "start": "babel-node -- src/cli/bin db.json -r routes.json",
     "lint": "eslint . --ignore-path .gitignore",
     "fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wll8/json-server",
-  "version": "0.17.2-alpha.3",
+  "version": "0.17.2-alpha.4",
   "description": "Get a full fake REST API with zero coding in less than 30 seconds",
   "main": "./lib/server/index.js",
   "bin": "./lib/cli/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wll8/json-server",
-  "version": "0.17.2-alpha.5",
+  "name": "json-server",
+  "version": "0.17.1",
   "description": "Get a full fake REST API with zero coding in less than 30 seconds",
   "main": "./lib/server/index.js",
   "bin": "./lib/cli/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wll8/json-server",
-  "version": "0.17.2-alpha.2",
+  "version": "0.17.2-alpha.3",
   "description": "Get a full fake REST API with zero coding in less than 30 seconds",
   "main": "./lib/server/index.js",
   "bin": "./lib/cli/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "json-server",
-  "version": "0.17.0",
+  "name": "@wll8/json-server",
+  "version": "0.17.2-alpha.2",
   "description": "Get a full fake REST API with zero coding in less than 30 seconds",
   "main": "./lib/server/index.js",
   "bin": "./lib/cli/bin.js",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -77,6 +77,16 @@ module.exports = function () {
         description: 'Path to config file',
         default: 'json-server.json',
       },
+      _noDbRoute: {
+        type: 'boolean',
+        description: 'Do not use the /db route',
+        default: false,
+      },
+      _noDataNext: {
+        type: 'boolean',
+        description: 'Enter a middleware when there is no data',
+        default: false,
+      },
     })
     .boolean('watch')
     .boolean('read-only')

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -35,14 +35,11 @@ function prettyPrint(argv, object, rules) {
 function createApp(db, routes, middlewares, argv) {
   const app = jsonServer.create()
 
-  const { foreignKeySuffix } = argv
-
-  const router = jsonServer.router(
-    db,
-    foreignKeySuffix ? { foreignKeySuffix } : undefined
-  )
+  const router = jsonServer.router(db, argv)
 
   const defaultsOpts = {
+    _noDataNext: argv._noDataNext,
+    _noDbRoute: argv._noDbRoute,
     logger: !argv.quiet,
     readOnly: argv.readOnly,
     noCors: argv.noCors,

--- a/src/server/defaults.js
+++ b/src/server/defaults.js
@@ -17,7 +17,7 @@ module.exports = function (opts) {
       noGzip: undefined,
       noCors: undefined,
       readOnly: undefined,
-      bodyParser: undefined,
+      bodyParser: undefined, // true / false / object
       logger: true,
       static: staticDir,
     },
@@ -75,8 +75,11 @@ module.exports = function (opts) {
   }
 
   // Add middlewares
-  if (opts.bodyParser) {
+  if (opts.bodyParser && typeof opts.bodyParser !== `object`) {
     arr.push(bodyParser)
+  }
+  if (opts.bodyParser && typeof opts.bodyParser === `object`) {
+    arr.push(opts.bodyParser)
   }
 
   return arr

--- a/src/server/defaults.js
+++ b/src/server/defaults.js
@@ -12,7 +12,17 @@ module.exports = function (opts) {
   const defaultDir = path.join(__dirname, '../../public')
   const staticDir = fs.existsSync(userDir) ? userDir : defaultDir
 
-  opts = Object.assign({ logger: true, static: staticDir }, opts)
+  opts = Object.assign(
+    {
+      noGzip: undefined,
+      noCors: undefined,
+      readOnly: undefined,
+      bodyParser: undefined,
+      logger: true,
+      static: staticDir,
+    },
+    opts
+  )
 
   const arr = []
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,9 @@
 const express = require('express')
 
 module.exports = {
+  lib: {
+    express,
+  },
   create: () => express().set('json spaces', 2),
   defaults: require('./defaults'),
   router: require('./router'),

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -19,6 +19,7 @@ module.exports = (db, opts) => {
       _isFake: false,
       _noDataNext: false,
       _noDbRoute: false,
+      bodyParser: undefined,
     },
     opts
   )
@@ -34,7 +35,7 @@ module.exports = (db, opts) => {
 
   // Add middlewares
   router.use(methodOverride())
-  router.use(bodyParser)
+  router.use(typeof opts.bodyParser === `object` ? opts.bodyParser : bodyParser)
 
   validateData(db.getState())
 

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -18,6 +18,7 @@ module.exports = (db, opts) => {
       foreignKeySuffix: 'Id',
       _isFake: false,
       _noDataNext: false,
+      _noDbRoute: false,
     },
     opts
   )
@@ -52,9 +53,10 @@ module.exports = (db, opts) => {
   }
 
   // GET /db
-  router.get('/db', (req, res) => {
-    res.jsonp(db.getState())
-  })
+  !opts._noDbRoute &&
+    router.get('/db', (req, res) => {
+      res.jsonp(db.getState())
+    })
 
   // Handle /:parent/:parentId/:resource
   const keys = Object.keys(db.value()).map((key) => `/${key}`)

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -60,9 +60,8 @@ module.exports = (db, opts) => {
 
   // Handle /:parent/:parentId/:resource
   const keys = Object.keys(db.value()).map((key) => `/${key}`)
-  opts._noDataNext && keys.length
-    ? router.use(keys, nested(opts))
-    : router.use(nested(opts))
+  opts._noDataNext && keys.length && router.use(keys, nested(opts))
+  !opts._noDataNext && router.use(nested(opts))
 
   // Create routes
   db.forEach((value, key) => {
@@ -97,9 +96,8 @@ module.exports = (db, opts) => {
     router.render(req, res)
   }
 
-  opts._noDataNext && keys.length
-    ? router.use(keys, render)
-    : router.use(render)
+  opts._noDataNext && keys.length && router.use(keys, render)
+  !opts._noDataNext && router.use(render)
   router.use((err, req, res, next) => {
     console.error(err.stack)
     res.status(500).send(err.stack)

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -1,5 +1,25 @@
 module.exports = {
+  parseArgv,
   getPage,
+}
+
+function parseArgv(arr) {
+  arr = typeof arr === 'string' ? arr.trim().split(/\s+/) : arr
+  return (arr || process.argv.slice(2)).reduce((acc, arg) => {
+    let [k, ...v] = arg.split(`=`)
+    v = v.join(`=`)
+    acc[k] =
+      v === ``
+        ? true
+        : /^(true|false)$/.test(v)
+        ? v === `true`
+        : /[\d|.]+/.test(v)
+        ? isNaN(Number(v))
+          ? v
+          : Number(v)
+        : v
+    return acc
+  }, {})
 }
 
 function getPage(array, page, perPage) {


### PR DESCRIPTION
- _noDataNext
  Allows entry to the next route when there is no data, which makes it work seamlessly with other programs
  
- _noDbRoute
  Assuming a db.json data breach poses a risk, it can be turned off with this option
  
- export express
  At present, it seems that json-server relies heavily on express and is inconvenient to upgrade, so using its dependencies directly will make me install one less package
  
- Allow custom bodyParser in jsonServer.router
  This way you can compile configure the size of the request body limit or some other thing
