### PR TITLE
Display type correctly for array if obj passed as an array

### DIFF
--- a/__tests__/server/validate-data.js
+++ b/__tests__/server/validate-data.js
@@ -7,7 +7,7 @@ describe('validateData', () => {
   })
 
   test('should throw an error if data is an array', () => {
-    assert.throws(() => validateData([]), /must be an object/)
+    assert.throws(() => validateData([]), /Data must be an object. Found array./)
   })
 
   test("shouldn't throw an error", () => {

--- a/src/server/router/validate-data.js
+++ b/src/server/router/validate-data.js
@@ -17,7 +17,7 @@ module.exports = (obj) => {
     Object.keys(obj).forEach(validateKey)
   } else {
     throw new Error(
-      `Data must be an object. Found ${typeof obj}.` +
+      `Data must be an object. Found ${Array.isArray(obj) ? 'array' : typeof obj}.` +
         'See https://github.com/typicode/json-server for example.'
     )
   }


### PR DESCRIPTION
If we pass an array instead of an object in the JSON file.
It throws an error like this; `Data must be an object. Found object.` which makes no sense.

This happens because typeof operator returns 'object' if you pass an array as an operand.

So, we should use Array.isArray to determine whether the passed value is an array instead of using typeof operator. We can use typeof as a fallback.