### PR TITLE
Update actions/checkout + actions/setup-node in CI to v3

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,9 +21,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
Updates the [`actions/checkout`](https://github.com/actions/checkout) and [`actions/setup-node`](https://github.com/actions/setup-node) actions used in the GitHub Actions workflow to their newest major version.

Still using v2 of `actions/checkout` or `actions/setup-node` will generate some warning like in this run: https://github.com/typicode/json-server/actions/runs/3689280970

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2

The PR will get rid of those warnings for `actions/checkout` and `actions/setup-node`, because v3 of both actions uses Node.js 16.