### PR TITLE
Prevent Access-Control-Expose-Headers header to be overwritten

### DIFF
--- a/src/server/router/plural.js
+++ b/src/server/router/plural.js
@@ -162,8 +162,8 @@ module.exports = (db, name, opts) => {
 
     // Slice result
     if (_end || _limit || _page) {
-      res.setHeader('X-Total-Count', chain.size())
-      res.setHeader(
+      res.append('X-Total-Count', chain.size())
+      res.append(
         'Access-Control-Expose-Headers',
         `X-Total-Count${_page ? ', Link' : ''}`,
       )


### PR DESCRIPTION
I tried using a middleware to create a new header to be consumed by a JavaScript web application, but I can't use the custom header because `Access-Control-Expose-Headers` won't allow it. So I decided to created the following middleware.
```
module.exports = (req, res, next) => {
    res.header('X-Hello', 'World');
    res.append('Access-Control-Expose-Headers', 'X-Hello');
    next();
}
```
But if I try the consume the API using using any pagination item, like `_page` Access-Control-Expose-Headers is overwritten by `Access-Control-Expose-Headers: X-Total-Count, Link` 
I also tried to create a custom server, but I got the same result
```
const jsonServer = require('json-server');
const server = jsonServer.create();
const router = jsonServer.router('./api/projects.json');
const middlewares = jsonServer.defaults();

server.use(middlewares);

server.use((req, res, next) => {
    res.setHeader(
        'X-Hello',
         'World'
    );

    res.setHeader(
        'Access-Control-Expose-Headers',
        'X-Hello',
    )

    next();
});


server.use(router);
server.listen(4000, () => {
    console.log('JSON Server is running');
});
```

This change will prevent the aforementioned header to be overwritten.