### PR TITLE
feat(cli): Add ctrl+c close

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -168,6 +168,11 @@ module.exports = function (argv) {
       })
       process.stdin.setEncoding('utf8')
       process.stdin.on('data', (chunk) => {
+        // ctrl+c or ctrl+d
+        if (chunk === '\x03' || chunk === '\x04') {
+          await app.close().finally(() => process.exit(1))
+          return
+        }
         if (chunk.trim().toLowerCase() === 's') {
           const filename = `db-${Date.now()}.json`
           const file = path.join(argv.snapshots, filename)


### PR DESCRIPTION
When using [npm-run-all](https://www.npmjs.com/package/npm-run-all) json-server does not close on ctrl+c SIGTERM signal. It's the same issue as vite has had https://github.com/vitejs/vite/issues/11434