### PR TITLE
Add explicit Node version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "public",
     "views"
   ],
+  "engines": {
+    "node": ">=18.3"
+  },
   "scripts": {
     "css": "tailwindcss -i ./views/input.css -o ./public/output.css",
     "watch-ts": "tsx watch src/bin.ts fixtures/db.json",


### PR DESCRIPTION
[`parseArgs`](https://nodejs.org/docs/latest-v20.x/api/util.html#utilparseargsconfig) was added to `node:util` in v16.17/v8.3. Given the CI workflow is only testing 18.x and 20.x, `>=18.3` seemed appropriate.

I also considered adding `18.3` explicitly to the `node-version` list in CI. However, note that the _tests_ rely on the [`--import` flag](https://nodejs.org/api/cli.html#--importmodule), new in v18.18<sup>1</sup>, so support for v18.3 can't be automatically validated. It would be possible to add some higher-level tests that start and make requests to `lib/bin.js` (I tried this out in v18.3, basically copied `src/app.test.ts` and made it JS, and it works fine).

<sup>1</sup> _Also it won't run in 18.18.2, the imports in the tests error out with `TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`, but everything's fine as of 18.19.0._