### PR TITLE
feat(cli): add --delay/-d option

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ const isProduction = process.env['NODE_ENV'] === 'production'
 export type AppOptions = {
   logger?: boolean
   static?: string[]
+  delay?: number
 }
 
 const eta = new Eta({
@@ -41,6 +42,11 @@ export function createApp(db: Low<Data>, options: AppOptions = {}) {
 
   // Body parser
   app.use(json())
+
+  // Delay middleware - optional
+  app.use((_req, _res, next) => {
+    setTimeout(next, options.delay || 0);
+  });
 
   app.get('/', (_req, res) =>
     res.send(eta.render('index.html', { data: db.data })),

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -22,6 +22,7 @@ Options:
   -p, --port <port>  Port (default: 3000)
   -h, --host <host>  Host (default: localhost)
   -s, --static <dir> Static files directory (multiple allowed)
+  -d, --delay        Delay response in milliseconds (default: 0)
   --help             Show this message
   --version          Show version number
 `)
@@ -33,6 +34,7 @@ function args(): {
   port: number
   host: string
   static: string[]
+  delay: number
 } {
   try {
     const { values, positionals } = parseArgs({
@@ -63,6 +65,10 @@ function args(): {
         watch: {
           type: 'boolean',
           short: 'w',
+        },
+        delay: {
+          type: 'string',
+          short: 'd',
         },
       },
       allowPositionals: true,
@@ -100,6 +106,7 @@ function args(): {
       port: parseInt(values.port as string),
       host: values.host as string,
       static: values.static as string[],
+      delay: parseInt(values.delay as string)
     }
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION') {
@@ -112,7 +119,7 @@ function args(): {
   }
 }
 
-const { file, port, host, static: staticArr } = args()
+const { file, port, host, static: staticArr, delay } = args()
 
 if (!existsSync(file)) {
   console.log(chalk.red(`File ${file} not found`))
@@ -140,7 +147,7 @@ const db = new Low<Data>(observer, {})
 await db.read()
 
 // Create app
-const app = createApp(db, { logger: false, static: staticArr })
+const app = createApp(db, { logger: false, static: staticArr, delay })
 
 function logRoutes(data: Data) {
   console.log(chalk.bold('Endpoints:'))


### PR DESCRIPTION
Adds an optional `--delay` (`-d` short) option to the CLI to delay responses.

**Changes:**
- added a global middleware in `app.js` with a `setTimeout` that invokes `next` after the specified delay duration.
- updated the executable `bin` logic to accept the '--delay' flag and pass it down to the `createApp` function.