### PR TITLE
support for getting nested resources

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -55,6 +55,7 @@ await test('createApp', async (t) => {
   // URLs
   const POSTS = '/posts'
   const POSTS_WITH_COMMENTS = '/posts?_embed=comments'
+  const POSTS_NESTED_WITH_COMMENTS = '/posts/1/comments'
   const POST_1 = '/posts/1'
   const POST_NOT_FOUND = '/posts/-1'
   const POST_WITH_COMMENTS = '/posts/1?_embed=comments'
@@ -76,6 +77,7 @@ await test('createApp', async (t) => {
     // API
     { method: 'GET', url: POSTS, statusCode: 200 },
     { method: 'GET', url: POSTS_WITH_COMMENTS, statusCode: 200 },
+    { method: 'GET', url: POSTS_NESTED_WITH_COMMENTS, statusCode: 200 },
     { method: 'GET', url: POST_1, statusCode: 200 },
     { method: 'GET', url: POST_NOT_FOUND, statusCode: 404 },
     { method: 'GET', url: POST_WITH_COMMENTS, statusCode: 200 },

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import { Low } from 'lowdb'
 import { json } from 'milliparsec'
 import sirv from 'sirv'
 
-import { Data, isItem, Service } from './service.js'
+import { Data, getNestedName, isItem, Service } from './service.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const isProduction = process.env['NODE_ENV'] === 'production'
@@ -65,6 +65,13 @@ export function createApp(db: Low<Data>, options: AppOptions = {}) {
   app.get('/:name/:id', (req, res, next) => {
     const { name = '', id = '' } = req.params
     res.locals['data'] = service.findById(name, id, req.query)
+    next()
+  })
+
+  app.get('/:name/:id/:nested_name', (req, res, next) => {
+    const { name = '', id = '', nested_name = '' } = req.params
+
+    res.locals['data'] = service.find(nested_name, { ...req.query, [getNestedName(name)]: id})
     next()
   })
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -13,6 +13,10 @@ export function isItem(obj: unknown): obj is Item {
   return typeof obj === 'object' && obj !== null
 }
 
+export function getNestedName(name: string): string {
+  return name[name.length-1] === 's' ? `${name.substring(0, name.length-1)}Id`: `${name}Id`;
+}
+
 export function isData(obj: unknown): obj is Record<string, Item[]> {
   if (typeof obj !== 'object' || obj === null) {
     return false


### PR DESCRIPTION
### Adds support for getting nested resources using a foreign key

There was previous support for nested resources in the previous version which I found helpful, I also found this comments
[#1556](https://github.com/typicode/json-server/issues/1556) and [#1567](https://github.com/typicode/json-server/issues/1567)
My implementation follows this comment here https://github.com/typicode/json-server/issues/72#issuecomment-99162206

### Example
`/environments/12/reports` should return `reports` where `environmentId === 12`