### PR TITLE
fix: handle undefined case in filtering logic

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -305,6 +305,8 @@ export class Service {
                   return itemValue === paramValue
                 case 'boolean':
                   return itemValue === (paramValue === 'true')
+                case 'undefined':
+                  return false
               }
             }
           }


### PR DESCRIPTION
# Fix: Optional Fields Filter

## Issue
When querying records with optional fields, records missing those fields were incorrectly included in results.

Example:
```json
// Data
{ "id": "1", "name": "test 1", "optionalField": "A" }
{ "id": "2", "name": "test 2" }  // missing optionalField

// Query: GET /records?optionalField=A
// Before: returned both records
// After: returns only record 1
```

## Solution
Added `case 'undefined': return false` in the default condition switch statement to properly filter out records with missing fields.

## Code Change

file :: src/service.ts   line :: 308

```typescript
case Condition.default: {
  switch (typeof itemValue) {
    case 'number':
      return itemValue === parseInt(paramValue)
    case 'string':
      return itemValue === paramValue
    case 'boolean':
      return itemValue === (paramValue === 'true')
    case 'undefined':
      return false  // ← New line
  }
}
```

Fixes #1647
