### PR TITLE
fix: handle UTF-8 BOM in JSON files

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -120,7 +120,16 @@ if (!existsSync(file)) {
 }
 
 // Handle empty string JSON file
-if (readFileSync(file, 'utf-8').trim() === '') {
+let fileContent = readFileSync(file, 'utf-8')
+
+// Strip UTF-8 BOM if present (U+FEFF)
+// Some editors (especially on Windows) add this invisible character at the start of files
+if (fileContent.charCodeAt(0) === 0xfeff) {
+  fileContent = fileContent.slice(1)
+  writeFileSync(file, fileContent)
+}
+
+if (fileContent.trim() === '') {
   writeFileSync(file, '{}')
 }
 


### PR DESCRIPTION
## Summary

Fixes #1631 — JSON files with UTF-8 BOM (byte order mark) cause `SyntaxError: Unexpected token` because the invisible BOM character (U+FEFF) is not valid JSON.

## Problem

Some text editors (especially on Windows like Notepad) add a UTF-8 BOM at the start of files. This invisible character causes JSON.parse to fail:

```
SyntaxError: Unexpected token '﻿', "﻿{   "pos"... is not valid JSON
```

## Solution

This PR adds BOM detection and stripping before JSON parsing:
- Checks if the first character is U+FEFF (BOM)
- If present, strips it from the content
- Writes the cleaned content back to the file (one-time fix)

## Testing

Tested by creating a JSON file with BOM - the server now starts correctly instead of throwing a parse error.