### PR TITLE
docs: add in operator to conditions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,14 @@ Operators:
 - `lt` less than, `lte` less than or equal
 - `gt` greater than, `gte` greater than or equal
 - `eq` equal, `ne` not equal
+- `in` included in comma-separated list
 
 Examples:
 
 ```http
 GET /posts?views:gt=100
 GET /posts?title:eq=Hello
+GET /posts?id:in=1,2,3
 GET /posts?author.name:eq=typicode
 ```
 


### PR DESCRIPTION
## Summary
- document the `in` query operator in the Conditions operator list
- add a matching `id:in=1,2,3` example alongside existing filter examples