### PR TITLE
fix: nested _where filters fail open when intermediate field is missing

### DIFF
--- a/src/matches-where.test.ts
+++ b/src/matches-where.test.ts
@@ -53,6 +53,11 @@ await test('matchesWhere', async (t) => {
     [{ c: { endsWith: 'z' } }, false],
     [{ a: { endsWith: '1' } }, false],
     [{ c: { endsWith: 1 } }, false],
+    // Regression tests for issue #1731: nested _where fail-open
+    // When intermediate field is not an object, nested predicates should fail (return false)
+    [{ a: { nested: { eq: 'zzz' } } }, false], // a is a number, not an object
+    [{ c: { nested: { eq: 'zzz' } } }, false], // c is a string, not an object
+    [{ or: [{ a: { nested: { eq: 'zzz' } } }] }, false],
   ]
 
   for (const [query, expected] of cases) {

--- a/src/matches-where.ts
+++ b/src/matches-where.ts
@@ -21,6 +21,19 @@ function getKnownOperators(value: unknown): WhereOperator[] {
   return ops
 }
 
+function hasKnownOperatorsAtAnyLevel(value: unknown): boolean {
+  if (!isJSONObject(value)) return false
+
+  const knownOps = getKnownOperators(value)
+  if (knownOps.length > 0) return true
+
+  for (const v of Object.values(value)) {
+    if (hasKnownOperatorsAtAnyLevel(v)) return true
+  }
+
+  return false
+}
+
 export function matchesWhere(obj: JsonObject, where: JsonObject): boolean {
   for (const [key, value] of Object.entries(where)) {
     if (key === 'or') {
@@ -74,6 +87,8 @@ export function matchesWhere(obj: JsonObject, where: JsonObject): boolean {
 
       if (isJSONObject(field)) {
         if (!matchesWhere(field, value)) return false
+      } else if (hasKnownOperatorsAtAnyLevel(value)) {
+        return false
       }
 
       continue


### PR DESCRIPTION
Fixes #1731

## Problem

Nested _where object filters currently fail open when the intermediate field does not exist on the target object or is not an object.

For example, with data `{ title: 'a' }`:
- `{ title: { eq: 'zzz' } }` correctly returns empty (no match)
- `{ title: { nested: { eq: 'zzz' } } }` incorrectly returns all rows (fail-open bug)

## Solution

Added `hasKnownOperatorsAtAnyLevel()` helper to detect when a nested object contains known operators at any depth. If it does, and the field is not an object, the filter now correctly returns false.

This preserves the existing fail-open behavior for unknown operators while fixing the fail-closed behavior for nested predicates on non-object fields.

## Changes

- Added `hasKnownOperatorsAtAnyLevel()` helper function in `src/matches-where.ts`
- Modified nested object handling to check for operators at any level
- Added regression tests for the specific bug cases

## Testing

All 130 tests pass, including 3 new regression tests for this specific issue.