### PR TITLE
Feature Proposal : adding Docker support for running json-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+dist
+coverage
+logs
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+EXPOSE 3000
+
+CMD ["node", "lib/bin.js", "fixtures/db.json"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ $ curl http://localhost:3000/posts/1
 
 Run `json-server --help` for a list of options
 
+## Run with Docker
+
+Build the image:
+
+```shell
+docker build -t json-server .
+```
+
+Run the container:
+
+```shell
+docker run --rm -p 3000:3000 json-server
+```
+
+API URL:
+
+```text
+http://localhost:3000
+```
+
 ## Sponsors ✨
 
 ### Gold


### PR DESCRIPTION
## Summary

Add Docker support so json-server can be built and run without requiring a local Node.js setup.

## What Changed

- Added a `Dockerfile`
- Added a `.dockerignore`
- Added a README section explaining how to build and run the project with Docker

## Why

This improves developer experience by making it easier to run the project in a consistent containerized environment.

It is also helpful for users on platforms where local build scripts may behave differently.

## How to test

```bash
docker build -t json-server .
docker run --rm -p 3000:3000 json-server