### PR TITLE
fix(service): support _embed=person when the resource key is persons

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+dist
+coverage
+logs
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+EXPOSE 3000
+
+CMD ["node", "lib/bin.js", "fixtures/db.json"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ $ curl http://localhost:3000/posts/1
 
 Run `json-server --help` for a list of options
 
+## Run with Docker
+
+Build the image:
+
+```shell
+docker build -t json-server .
+```
+
+Run the container:
+
+```shell
+docker run --rm -p 3000:3000 json-server
+```
+
+API URL:
+
+```text
+http://localhost:3000
+```
+
 ## Sponsors ✨
 
 ### Gold

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -117,6 +117,23 @@ await test('find', async (t) => {
   }
 })
 
+await test('find supports _embed=person when the resource key is persons', () => {
+  const db = new Low<Data>(new Memory<Data>(), {
+    feedbacks: [{ id: '1', text: 'a', personId: '1' }],
+    persons: [{ id: '1', name: 'Tim' }],
+  })
+  const service = new Service(db)
+
+  assert.deepEqual(service.find('feedbacks', { where: {}, embed: 'person' }), [
+    {
+      id: '1',
+      text: 'a',
+      personId: '1',
+      person: { id: '1', name: 'Tim' },
+    },
+  ])
+})
+
 await test('create', async () => {
   const post = { title: 'new post' }
   const res = await service.create(POSTS, post)

--- a/src/service.ts
+++ b/src/service.ts
@@ -34,7 +34,13 @@ function ensureArray(arg: string | string[] = []): string[] {
 
 function embed(db: Low<Data>, name: string, item: Item, related: string): Item {
   if (inflection.singularize(related) === related) {
-    const relatedData = db.data[inflection.pluralize(related)] as Item[]
+    const pluralized = db.data[inflection.pluralize(related)]
+    const suffixed = db.data[`${related}s`]
+    const relatedData = Array.isArray(pluralized)
+      ? pluralized
+      : Array.isArray(suffixed)
+        ? suffixed
+        : undefined
     if (!relatedData) {
       return item
     }


### PR DESCRIPTION
Fixes #1634

## Summary

Singular `_embed` lookups currently resolve related collections through `inflection.pluralize()`.

That breaks cases like `_embed=person` when the resource key is `persons`, because `inflection.pluralize('person')` returns `people`, so the lookup misses and the relation is not embedded.

## Reproduction

With:

```json
{
  "persons": [
    { "id": "1", "name": "Tim" }
  ],
  "feedbacks": [
    { "id": "1", "personId": "1", "text": "Great dev" }
  ]
}