### PR TITLE
fix: handle BOM in JSON parsing

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -126,13 +126,18 @@ if (readFileSync(file, "utf-8").trim() === "") {
 
 // Set up database
 let adapter: Adapter<RawData>;
+const stripBom = (text: string) => text.replace(/^\uFEFF/, '')
+
 if (extname(file) === ".json5") {
   adapter = new DataFile<RawData>(file, {
-    parse: JSON5.parse,
+    parse: (text) => JSON5.parse(stripBom(text)),
     stringify: JSON5.stringify,
-  });
+  })
 } else {
-  adapter = new JSONFile<RawData>(file);
+  adapter = new DataFile<RawData>(file, {
+    parse: (text) => JSON.parse(stripBom(text)) as RawData,
+    stringify: (data) => JSON.stringify(data, null, 2),
+  })
 }
 const observer = new Observer(new NormalizedAdapter(adapter));
 


### PR DESCRIPTION
This PR fixes an issue where JSON files containing a BOM (Byte Order Mark) cause a SyntaxError during parsing.

## Cause
lowdb's JSONFile adapter uses JSON.parse directly, which fails when encountering BOM characters.

## Solution
Replaced JSONFile with DataFile and introduced a custom parse function that strips BOM before parsing.

This ensures compatibility with UTF-8 BOM encoded JSON files without modifying the file on disk.